### PR TITLE
Add start date and dueComplete support for Trello cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Update an existing card's details.
     description?: string, // Optional: New description
     dueDate?: string,     // Optional: New due date (ISO 8601 format with time)
     start?: string,       // Optional: New start date (YYYY-MM-DD format, date only)
+    dueComplete?: boolean,// Optional: Mark the due date as complete (true) or incomplete (false)
     labels?: string[]     // Optional: New array of label IDs
   }
 }

--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ This allows you to work with multiple boards and workspaces without restarting t
 }
 ```
 
+## Date Format Guidelines
+
+When working with dates in the Trello MCP server, please note the different format requirements:
+
+- **Due Date (`dueDate`)**: Accepts full ISO 8601 format with time (e.g., `2023-12-31T12:00:00Z`)
+- **Start Date (`start`)**: Accepts date only in YYYY-MM-DD format (e.g., `2025-08-05`)
+
+This distinction follows Trello's API conventions where start dates are day-based markers while due dates can include specific times.
+
 ## Available Tools
 
 ### get_cards_by_list_id
@@ -318,8 +327,9 @@ Add a new card to a specified list.
     listId: string,       // ID of the list to add the card to
     name: string,         // Name of the card
     description?: string, // Optional: Description of the card
-    dueDate?: string,    // Optional: Due date (ISO 8601 format)
-    labels?: string[]    // Optional: Array of label IDs
+    dueDate?: string,     // Optional: Due date (ISO 8601 format with time)
+    start?: string,       // Optional: Start date (YYYY-MM-DD format, date only)
+    labels?: string[]     // Optional: Array of label IDs
   }
 }
 ```
@@ -336,8 +346,9 @@ Update an existing card's details.
     cardId: string,       // ID of the card to update
     name?: string,        // Optional: New name for the card
     description?: string, // Optional: New description
-    dueDate?: string,    // Optional: New due date (ISO 8601 format)
-    labels?: string[]    // Optional: New array of label IDs
+    dueDate?: string,     // Optional: New due date (ISO 8601 format with time)
+    start?: string,       // Optional: New start date (YYYY-MM-DD format, date only)
+    labels?: string[]     // Optional: New array of label IDs
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@delorenj/mcp-server-trello",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Model Context Protocol (MCP) server for interacting with Trello boards",
   "type": "module",
   "main": "build/index.js",

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -35,7 +35,7 @@ const add_card_to_listEval: EvalFunction = {
     name: 'add_card_to_listEval',
     description: 'Evaluates the add_card_to_list tool',
     run: async () => {
-        const result = await grade(openai("gpt-4"), "Please add a new card named 'Demo Card' to the list with ID 'abc123', with a description of 'This is a test card', due date '2023-12-31T12:00:00Z', and a label 'priority'.");
+        const result = await grade(openai("gpt-4"), "Please add a new card named 'Demo Card' to the list with ID 'abc123', with a description of 'This is a test card', due date '2023-12-31T12:00:00Z', start date '2025-08-05', and a label 'priority'.");
         return JSON.parse(result);
     }
 };
@@ -44,7 +44,7 @@ const update_card_detailsEval: EvalFunction = {
     name: 'update_card_details Evaluation',
     description: 'Evaluates the update_card_details tool functionality',
     run: async () => {
-        const result = await grade(openai("gpt-4"), "Please update the card with ID 'abc123' to have the name 'Updated Card Name', the description 'New description for the card', a due date of '2024-01-01T10:00:00Z', and labels ['priority','review'].");
+        const result = await grade(openai("gpt-4"), "Please update the card with ID 'abc123' to have the name 'Updated Card Name', the description 'New description for the card', a due date of '2024-01-01T10:00:00Z', start date '2025-08-05', and labels ['priority','review'].");
         return JSON.parse(result);
     }
 };

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -49,11 +49,20 @@ const update_card_detailsEval: EvalFunction = {
     }
 };
 
+const mark_card_completeEval: EvalFunction = {
+    name: 'mark_card_complete Evaluation',
+    description: 'Evaluates the ability to mark a card as complete using dueComplete',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please mark the card with ID 'xyz789' as complete by setting dueComplete to true.");
+        return JSON.parse(result);
+    }
+};
+
 const config: EvalConfig = {
     model: openai("gpt-4"),
-    evals: [get_cards_by_list_idEval, get_listsEval, get_recent_activityEvalFunction, add_card_to_listEval, update_card_detailsEval]
+    evals: [get_cards_by_list_idEval, get_listsEval, get_recent_activityEvalFunction, add_card_to_listEval, update_card_detailsEval, mark_card_completeEval]
 };
   
 export default config;
   
-export const evals = [get_cards_by_list_idEval, get_listsEval, get_recent_activityEvalFunction, add_card_to_listEval, update_card_detailsEval];
+export const evals = [get_cards_by_list_idEval, get_listsEval, get_recent_activityEvalFunction, add_card_to_listEval, update_card_detailsEval, mark_card_completeEval];

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,10 @@ class TrelloServer {
                 type: 'string',
                 description: 'New start date for the card (YYYY-MM-DD format, date only)',
               },
+              dueComplete: {
+                type: 'boolean',
+                description: 'Mark the due date as complete (true) or incomplete (false)',
+              },
               labels: {
                 type: 'array',
                 items: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,10 @@ class TrelloServer {
                 type: 'string',
                 description: 'Due date for the card (ISO 8601 format)',
               },
+              start: {
+                type: 'string',
+                description: 'Start date for the card (YYYY-MM-DD format, date only)',
+              },
               labels: {
                 type: 'array',
                 items: {
@@ -183,6 +187,10 @@ class TrelloServer {
               dueDate: {
                 type: 'string',
                 description: 'New due date for the card (ISO 8601 format)',
+              },
+              start: {
+                type: 'string',
+                description: 'New start date for the card (YYYY-MM-DD format, date only)',
               },
               labels: {
                 type: 'array',
@@ -507,10 +515,12 @@ class TrelloServer {
             try {
               const board = await this.trelloClient.setActiveBoard(validArgs.boardId);
               return {
-                content: [{ 
-                  type: 'text', 
-                  text: `Successfully set active board to "${board.name}" (${board.id})`
-                }],
+                content: [
+                  {
+                    type: 'text',
+                    text: `Successfully set active board to "${board.name}" (${board.id})`,
+                  },
+                ],
               };
             } catch (error) {
               return this.handleErrorResponse(error);
@@ -529,10 +539,12 @@ class TrelloServer {
             try {
               const workspace = await this.trelloClient.setActiveWorkspace(validArgs.workspaceId);
               return {
-                content: [{ 
-                  type: 'text', 
-                  text: `Successfully set active workspace to "${workspace.displayName}" (${workspace.id})`
-                }],
+                content: [
+                  {
+                    type: 'text',
+                    text: `Successfully set active workspace to "${workspace.displayName}" (${workspace.id})`,
+                  },
+                ],
               };
             } catch (error) {
               return this.handleErrorResponse(error);
@@ -559,14 +571,20 @@ class TrelloServer {
               }
               const board = await this.trelloClient.getBoardById(boardId);
               return {
-                content: [{ 
-                  type: 'text', 
-                  text: JSON.stringify({
-                    ...board,
-                    isActive: true,
-                    activeWorkspaceId: this.trelloClient.activeWorkspaceId || 'Not set'
-                  }, null, 2)
-                }],
+                content: [
+                  {
+                    type: 'text',
+                    text: JSON.stringify(
+                      {
+                        ...board,
+                        isActive: true,
+                        activeWorkspaceId: this.trelloClient.activeWorkspaceId || 'Not set',
+                      },
+                      null,
+                      2
+                    ),
+                  },
+                ],
               };
             } catch (error) {
               return this.handleErrorResponse(error);
@@ -605,7 +623,7 @@ class TrelloServer {
   async run() {
     const transport = new StdioServerTransport();
     // Load configuration before starting the server
-    await this.trelloClient.loadConfig().catch((error) => {
+    await this.trelloClient.loadConfig().catch(_error => {
       // Continue with default config if loading fails
     });
     await this.server.connect(transport);

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -246,6 +246,7 @@ export class TrelloClient {
       name: string;
       description?: string;
       dueDate?: string;
+      start?: string;
       labels?: string[];
     }
   ): Promise<TrelloCard> {
@@ -255,6 +256,7 @@ export class TrelloClient {
         name: params.name,
         desc: params.description,
         due: params.dueDate,
+        start: params.start,
         idLabels: params.labels,
       });
       return response.data;
@@ -268,6 +270,7 @@ export class TrelloClient {
       name?: string;
       description?: string;
       dueDate?: string;
+      start?: string;
       labels?: string[];
     }
   ): Promise<TrelloCard> {
@@ -276,6 +279,7 @@ export class TrelloClient {
         name: params.name,
         desc: params.description,
         due: params.dueDate,
+        start: params.start,
         idLabels: params.labels,
       });
       return response.data;

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -271,6 +271,7 @@ export class TrelloClient {
       description?: string;
       dueDate?: string;
       start?: string;
+      dueComplete?: boolean;
       labels?: string[];
     }
   ): Promise<TrelloCard> {
@@ -280,6 +281,7 @@ export class TrelloClient {
         desc: params.description,
         due: params.dueDate,
         start: params.start,
+        dueComplete: params.dueComplete,
         idLabels: params.labels,
       });
       return response.data;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -36,6 +36,14 @@ export function validateOptionalStringArray(value: unknown): string[] | undefine
   return validateStringArray(value);
 }
 
+export function validateOptionalBoolean(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') {
+    throw new McpError(ErrorCode.InvalidParams, 'Value must be a boolean');
+  }
+  return value;
+}
+
 export function validateOptionalDateString(value: unknown): string | undefined {
   if (value === undefined) return undefined;
   const dateStr = validateString(value, 'date');
@@ -105,6 +113,7 @@ export function validateUpdateCardRequest(args: Record<string, unknown>): {
   description?: string;
   dueDate?: string;
   start?: string;
+  dueComplete?: boolean;
   labels?: string[];
 } {
   if (!args.cardId) {
@@ -117,6 +126,7 @@ export function validateUpdateCardRequest(args: Record<string, unknown>): {
     description: validateOptionalString(args.description),
     dueDate: validateOptionalString(args.dueDate),
     start: validateOptionalDateString(args.start),
+    dueComplete: validateOptionalBoolean(args.dueComplete),
     labels: validateOptionalStringArray(args.labels),
   };
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -36,6 +36,15 @@ export function validateOptionalStringArray(value: unknown): string[] | undefine
   return validateStringArray(value);
 }
 
+export function validateOptionalDateString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const dateStr = validateString(value, 'date');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    throw new McpError(ErrorCode.InvalidParams, 'date must be in YYYY-MM-DD format');
+  }
+  return dateStr;
+}
+
 export function validateGetCardsListRequest(args: Record<string, unknown>): {
   boardId?: string;
   listId: string;
@@ -84,7 +93,7 @@ export function validateAddCardRequest(args: Record<string, unknown>): {
     name: validateString(args.name, 'name'),
     description: validateOptionalString(args.description),
     dueDate: validateOptionalString(args.dueDate),
-    start: validateOptionalString(args.start),
+    start: validateOptionalDateString(args.start),
     labels: validateOptionalStringArray(args.labels),
   };
 }
@@ -107,7 +116,7 @@ export function validateUpdateCardRequest(args: Record<string, unknown>): {
     name: validateOptionalString(args.name),
     description: validateOptionalString(args.description),
     dueDate: validateOptionalString(args.dueDate),
-    start: validateOptionalString(args.start),
+    start: validateOptionalDateString(args.start),
     labels: validateOptionalStringArray(args.labels),
   };
 }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -71,17 +71,20 @@ export function validateAddCardRequest(args: Record<string, unknown>): {
   name: string;
   description?: string;
   dueDate?: string;
+  start?: string;
   labels?: string[];
 } {
   if (!args.listId || !args.name) {
     throw new McpError(ErrorCode.InvalidParams, 'listId and name are required');
   }
+
   return {
     boardId: args.boardId ? validateString(args.boardId, 'boardId') : undefined,
     listId: validateString(args.listId, 'listId'),
     name: validateString(args.name, 'name'),
     description: validateOptionalString(args.description),
     dueDate: validateOptionalString(args.dueDate),
+    start: validateOptionalString(args.start),
     labels: validateOptionalStringArray(args.labels),
   };
 }
@@ -92,6 +95,7 @@ export function validateUpdateCardRequest(args: Record<string, unknown>): {
   name?: string;
   description?: string;
   dueDate?: string;
+  start?: string;
   labels?: string[];
 } {
   if (!args.cardId) {
@@ -103,6 +107,7 @@ export function validateUpdateCardRequest(args: Record<string, unknown>): {
     name: validateOptionalString(args.name),
     description: validateOptionalString(args.description),
     dueDate: validateOptionalString(args.dueDate),
+    start: validateOptionalString(args.start),
     labels: validateOptionalStringArray(args.labels),
   };
 }


### PR DESCRIPTION
- Add start date parameter to add_card_to_list and update_card_details tools
- Add dueComplete parameter to update_card_details tool for marking due dates as complete
- Update validators to handle start date field and dueComplete boolean
- Add date format guidelines to README
- Update evaluations to include start date and dueComplete examples
- Support YYYY-MM-DD format for start dates (date only)
- Maintain ISO 8601 format for due dates (with time)

This PR adds two new features:
1. **Start Date Support**: Cards can now have a start date (date only) in addition to the due date (with time)
2. **Due Date Completion**: Cards can now be marked as having their due date completed via the dueComplete boolean parameter