### PR TITLE
feat: local image and file attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Attach an image to a card directly from a URL.
 
 ### attach_file_to_card
 
-Attach any type of file to a card from a URL (PDFs, documents, videos, etc.).
+Attach any type of file to a card from a URL or a local file path (e.g., `file:///path/to/your/file.pdf`).
 
 ```typescript
 {
@@ -610,12 +610,11 @@ Attach any type of file to a card from a URL (PDFs, documents, videos, etc.).
   arguments: {
     boardId?: string,  // Optional: ID of the board (uses default if not provided)
     cardId: string,    // ID of the card to attach the file to
-    fileUrl: string,   // URL of the file to attach
-    name?: string,     // Optional: Name for the attachment (defaults to "File Attachment")
+    fileUrl: string,   // URL or local file path (using the file:// protocol) of the file to attach
+    name?: string,     // Optional: Name for the attachment (defaults to the file name for local files)
     mimeType?: string  // Optional: MIME type (e.g., "application/pdf", "text/plain", "video/mp4")
   }
 }
-```
 
 ### list_boards
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ A Model Context Protocol (MCP) server that provides tools for interacting with T
 - Improved error handling for image attachment functionality
 - Updated documentation for attach_image_to_card tool
 
+### 0.2.1
+
+- Added `attach_file_to_card` tool to attach any type of file (PDFs, documents, videos, etc.) to cards from URLs
+- Enhanced attachment support beyond just images
+- Kept `attach_image_to_card` for backward compatibility
+
 ### 0.2.0
 
 - Added `attach_image_to_card` tool to attach images to cards from URLs
@@ -109,6 +115,7 @@ A Model Context Protocol (MCP) server that provides tools for interacting with T
 
 - **Full Trello Board Integration**: Interact with cards, lists, and board activities
 - **🆕 Complete Card Data Extraction**: Fetch all card details including checklists, attachments, labels, members, and comments
+- **File Attachments**: Attach any type of file to cards (PDFs, documents, videos, images, etc.) from URLs
 - **Built-in Rate Limiting**: Respects Trello's API limits (300 requests/10s per API key, 100 requests/10s per token)
 - **Type-Safe Implementation**: Written in TypeScript with comprehensive type definitions
 - **Input Validation**: Robust validation for all API inputs
@@ -589,6 +596,23 @@ Attach an image to a card directly from a URL.
     cardId: string,   // ID of the card to attach the image to
     imageUrl: string, // URL of the image to attach
     name?: string     // Optional: Name for the attachment (defaults to "Image Attachment")
+  }
+}
+```
+
+### attach_file_to_card
+
+Attach any type of file to a card from a URL (PDFs, documents, videos, etc.).
+
+```typescript
+{
+  name: 'attach_file_to_card',
+  arguments: {
+    boardId?: string,  // Optional: ID of the board (uses default if not provided)
+    cardId: string,    // ID of the card to attach the file to
+    fileUrl: string,   // URL of the file to attach
+    name?: string,     // Optional: Name for the attachment (defaults to "File Attachment")
+    mimeType?: string  // Optional: MIME type (e.g., "application/pdf", "text/plain", "video/mp4")
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "@ai-sdk/openai": "^1.3.23",
-    "@types/form-data": "^2.5.2",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.6.2",
+    "form-data": "^4.0.4",
     "mcp-evals": "^1.0.18",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@ai-sdk/openai": "^1.3.23",
+    "@types/form-data": "^2.5.2",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^1.3.23
         version: 1.3.23(zod@3.25.76)
-      '@types/form-data':
-        specifier: ^2.5.2
-        version: 2.5.2
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.8
@@ -362,10 +359,6 @@ packages:
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
-
-  '@types/form-data@2.5.2':
-    resolution: {integrity: sha512-tfmcyHn1Pp9YHAO5r40+UuZUPAZbUEgqTel3EuEKpmF9hPkXgR4l41853raliXnb4gwyPNoQOfvgGGlHN5WSog==}
-    deprecated: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1702,10 +1695,6 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@types/diff-match-patch@1.0.36': {}
-
-  '@types/form-data@2.5.2':
-    dependencies:
-      form-data: 4.0.4
 
   '@types/json-schema@7.0.15': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       axios:
         specifier: ^1.6.2
         version: 1.10.0
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.4
       mcp-evals:
         specifier: ^1.0.18
         version: 1.0.18(react@19.1.0)(zod@3.25.76)
@@ -24,6 +27,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^1.3.23
         version: 1.3.23(zod@3.25.76)
+      '@types/form-data':
+        specifier: ^2.5.2
+        version: 2.5.2
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.8
@@ -356,6 +362,10 @@ packages:
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
+  '@types/form-data@2.5.2':
+    resolution: {integrity: sha512-tfmcyHn1Pp9YHAO5r40+UuZUPAZbUEgqTel3EuEKpmF9hPkXgR4l41853raliXnb4gwyPNoQOfvgGGlHN5WSog==}
+    deprecated: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1692,6 +1702,10 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@types/diff-match-patch@1.0.36': {}
+
+  '@types/form-data@2.5.2':
+    dependencies:
+      form-data: 4.0.4
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
Add support for uploading local files directly to Trello cards alongside existing URL-based attachments.

Changes:
- Add new generic attachFileToCard() method supporting both local files (file://) and URLs
- Add multipart/form-data upload support for local files using Node.js streams
- Maintain backward compatibility by keeping attachImageToCard() as a wrapper
- Add comprehensive file type support including documents, images, videos, archives, and code files

Dependencies:
- Add form-data package for multipart uploads
- Add @types/form-data for TypeScript support

This enables users to attach local files directly to Trello cards without needing to host them externally first.