### PR TITLE
Update command and args in README for Trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ If you have [Bun](https://bun.sh) installed, using `bunx` is the fastest way to 
 {
   "mcpServers": {
     "trello": {
-      "command": "bunx",
-      "args": ["@delorenj/mcp-server-trello"],
+      "command": "bun",
+      "args": ["x", "@delorenj/mcp-server-trello"],
       "env": {
         "TRELLO_API_KEY": "your-api-key",
         "TRELLO_TOKEN": "your-token"


### PR DESCRIPTION
bunx gives me this error
```
$ bunx @delorenj/mcp-server-trello 
   error: Script not found "@delorenj/mcp-server-trello"
```
```
bun x @delorenj/mcp-server-trello
```

runs just fine. fixed README first part to reflect that

I am running bun 1.3.4