### PR TITLE
feat: add pos parameter to move_card for list position control

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,11 +253,15 @@ class TrelloServer {
             ),
           cardId: z.string().describe('ID of the card to move'),
           listId: z.string().describe('ID of the target list'),
+          pos: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe('Position in target list: "top", "bottom", or a positive number'),
         },
       },
-      async ({ boardId, cardId, listId }) => {
+      async ({ boardId, cardId, listId, pos }) => {
         try {
-          const card = await this.trelloClient.moveCard(boardId, cardId, listId);
+          const card = await this.trelloClient.moveCard(boardId, cardId, listId, pos);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(card, null, 2) }],
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,9 +254,9 @@ class TrelloServer {
           cardId: z.string().describe('ID of the card to move'),
           listId: z.string().describe('ID of the target list'),
           pos: z
-            .union([z.string(), z.number()])
-            .optional()
-            .describe('Position in target list: "top", "bottom", or a positive number'),
+          .union([z.enum(['top', 'bottom']), z.number().positive()])
+          .optional()
+          .describe('Position in target list: "top", "bottom", or a positive number'),
         },
       },
       async ({ boardId, cardId, listId, pos }) => {

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -346,12 +346,13 @@ export class TrelloClient {
     });
   }
 
-  async moveCard(boardId: string | undefined, cardId: string, listId: string): Promise<TrelloCard> {
+  async moveCard(boardId: string | undefined, cardId: string, listId: string, pos?: string | number): Promise<TrelloCard> {
     const effectiveBoardId = boardId || this.defaultBoardId;
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.put(`/cards/${cardId}`, {
         idList: listId,
         ...(effectiveBoardId && { idBoard: effectiveBoardId }),
+        ...(pos && { pos }),
       });
       return response.data;
     });


### PR DESCRIPTION
Closes #51
Adds an optional pos parameter to the move_card tool, allowing control over card position within the target list.
Changes:

Added pos to move_card input schema (accepts "top", "bottom", or numeric value)
Updated moveCard client method to include pos in the API request

Usage:
javascript// Move card to top of list
move_card({ cardId: "xxx", listId: "yyy", pos: "top" })

// Move card to specific position
move_card({ cardId: "xxx", listId: "yyy", pos: 140737487919104 })
Tested and working in Claude Desktop.