### PR TITLE
feat: Add download_attachment tool for fetching card attachments

### DIFF
--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1101,6 +1101,7 @@ export class TrelloClient {
 
       // Download using OAuth header (required for attachment downloads)
       const downloadUrl = `https://api.trello.com/1/cards/${cardId}/attachments/${attachmentId}/download/${encodeURIComponent(attachment.fileName)}`;
+      await this.rateLimiter.waitForAvailableToken();
       const response = await axios.get(downloadUrl, {
         headers: {
           Authorization: `OAuth oauth_consumer_key="${this.config.apiKey}", oauth_token="${this.config.token}"`,

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1102,9 +1102,10 @@ export class TrelloClient {
       // Download using OAuth header (required for attachment downloads)
       const downloadUrl = `https://api.trello.com/1/cards/${cardId}/attachments/${attachmentId}/download/${encodeURIComponent(attachment.fileName)}`;
       await this.rateLimiter.waitForAvailableToken();
+      await this.rateLimiter.waitForAvailableToken();
       const response = await axios.get(downloadUrl, {
         headers: {
-          Authorization: `OAuth oauth_consumer_key="${this.config.apiKey}", oauth_token="${this.config.token}"`,
+          Authorization: 'OAuth oauth_consumer_key="' + this.config.apiKey + '", oauth_token="' + this.config.token + '"',
         },
         responseType: 'arraybuffer',
       });


### PR DESCRIPTION
## Problem

Currently there's no way to download/view attachments from Trello cards through the MCP server. The attachment URLs returned by `get_card` require authentication and cannot be accessed directly.

## Solution

Added a new `download_attachment` tool that:
- Fetches attachment metadata
- Downloads the file using OAuth authentication header
- Returns base64-encoded data (images are returned as viewable content)

## Implementation Details

- Uses OAuth header: `Authorization: OAuth oauth_consumer_key="...", oauth_token="..."`
- Query parameters don't work for attachment downloads (returns 401)
- Reference: https://community.developer.atlassian.com/t/download-attachments-with-api/72386

## Usage

```json
{
  "cardId": "card-id-or-shortlink",
  "attachmentId": "attachment-id"
}
```

## Changes

- `src/trello-client.ts`: Added `downloadAttachment()` method
- `src/index.ts`: Registered `download_attachment` tool

## Testing

Tested manually with real Trello attachments - successfully downloads and returns images as base64 data.