### PR TITLE
feat: add fields parameter to get_cards_by_list_id for token efficiency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,11 +68,15 @@ class TrelloServer {
             .optional()
             .describe('ID of the Trello board (uses default if not provided)'),
           listId: z.string().describe('ID of the Trello list'),
+          fields: z
+            .string()
+            .optional()
+            .describe('Comma-separated list of fields to return (e.g., "name,idShort,labels,due,dueComplete"). Omit for all fields.'),
         },
       },
-      async ({ boardId, listId }) => {
+      async ({ boardId, listId, fields }) => {
         try {
-          const cards = await this.trelloClient.getCardsByList(boardId, listId);
+          const cards = await this.trelloClient.getCardsByList(boardId, listId, fields);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(cards, null, 2) }],
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ class TrelloServer {
       },
       async ({ boardId, listId, fields }) => {
         try {
-          const cards = await this.trelloClient.getCardsByList(boardId, listId, fields);
+          const cards = await this.trelloClient.getCardsByList(listId, fields);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(cards, null, 2) }],
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ class TrelloServer {
             .describe('Comma-separated list of fields to return (e.g., "name,idShort,labels,due,dueComplete"). Omit for all fields.'),
         },
       },
-      async ({ boardId, listId, fields }) => {
+      async ({ listId, fields }) => {
         try {
           const cards = await this.trelloClient.getCardsByList(listId, fields);
           return {

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -251,9 +251,10 @@ export class TrelloClient {
     });
   }
 
-  async getCardsByList(boardId: string | undefined, listId: string): Promise<TrelloCard[]> {
+  async getCardsByList(boardId: string | undefined, listId: string, fields?: string): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
-      const response = await this.axiosInstance.get(`/lists/${listId}/cards`);
+      const params = fields ? { fields } : {};
+      const response = await this.axiosInstance.get(`/lists/${listId}/cards`, { params });
       return response.data;
     });
   }

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -251,7 +251,7 @@ export class TrelloClient {
     });
   }
 
-  async getCardsByList(boardId: string | undefined, listId: string, fields?: string): Promise<TrelloCard[]> {
+  async getCardsByList(listId: string, fields?: string): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
       const params = fields ? { fields } : {};
       const response = await this.axiosInstance.get(`/lists/${listId}/cards`, { params });


### PR DESCRIPTION
## Summary

Adds an optional `fields` parameter to `get_cards_by_list_id` that allows callers to specify which card fields to return.

This reduces response size significantly when full card data (especially lengthy descriptions) isn't needed - useful for LLM contexts where token efficiency matters.

## Changes

**trello-client.ts:**
```typescript
async getCardsByList(boardId: string | undefined, listId: string, fields?: string): Promise<TrelloCard[]> {
  return this.handleRequest(async () => {
    const params = fields ? { fields } : {};
    const response = await this.axiosInstance.get(`/lists/${listId}/cards`, { params });
    return response.data;
  });
}
```

**index.ts:** Added `fields` parameter to the tool schema with description.

## Usage

```typescript
// Get all fields (existing behavior)
get_cards_by_list_id({ listId: "abc123" })

// Get only essential fields (new)
get_cards_by_list_id({ listId: "abc123", fields: "name,idShort,labels,due,dueComplete" })
```

## Related

Closes #57