### PR TITLE
feat: add TRELLO_ALLOWED_WORKSPACES env var for workspace restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ When `TRELLO_ALLOWED_WORKSPACES` is set:
 Example configuration:
 ```bash
 # Only allow access to two specific workspaces
-TRELLO_ALLOWED_WORKSPACES=697c549ce04dc460af133a75,5f8a3b2c1d4e5f6g7h8i9j0k
+TRELLO_ALLOWED_WORKSPACES=697c549ce04dc460af133a75,5f8a3b2c1d4e5f6a7b8c9d0e
 ```
 
 If `TRELLO_ALLOWED_WORKSPACES` is not set or empty, all workspaces the token has access to will be available (default behaviour).

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ TRELLO_WORKSPACE_ID=your-workspace-id
 
 # Optional: HTTPS proxy URL (for corporate proxies or restricted networks)
 https_proxy=http://your-proxy:8080
+
+# Optional: Restrict access to specific workspaces (comma-separated IDs)
+# If set, only the listed workspaces will be accessible via MCP tools
+TRELLO_ALLOWED_WORKSPACES=workspace-id-1,workspace-id-2
 ```
 
 > **Proxy Support:** If you're behind a corporate proxy or in an environment that routes traffic through a proxy, set the `https_proxy` or `HTTPS_PROXY` environment variable. The server will automatically route all Trello API requests through the specified proxy.
@@ -120,6 +124,29 @@ Starting with version 0.3.0, the MCP server supports multiple ways to work with 
        - Similarly, you can set and persist an active workspace using `set_active_workspace`
 
 This allows you to work with multiple boards and workspaces without restarting the server.
+
+### Workspace Access Restriction
+
+You can optionally restrict MCP access to specific workspaces using the `TRELLO_ALLOWED_WORKSPACES` environment variable. This is useful for:
+
+- **Security**: Limiting AI agent access to only approved workspaces
+- **Multi-tenant setups**: Ensuring agents only access relevant workspaces
+- **Testing**: Isolating test environments from production data
+
+When `TRELLO_ALLOWED_WORKSPACES` is set:
+- `list_workspaces` only returns workspaces in the allowed list
+- `list_boards` only returns boards from allowed workspaces
+- `set_active_workspace` rejects workspaces not in the allowed list
+- `list_boards_in_workspace` rejects non-allowed workspace IDs
+- `create_board` rejects creation in non-allowed workspaces
+
+Example configuration:
+```bash
+# Only allow access to two specific workspaces
+TRELLO_ALLOWED_WORKSPACES=697c549ce04dc460af133a75,5f8a3b2c1d4e5f6g7h8i9j0k
+```
+
+If `TRELLO_ALLOWED_WORKSPACES` is not set or empty, all workspaces the token has access to will be available (default behaviour).
 
 #### Example Workflow
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,23 @@ class TrelloServer {
     const apiKey = process.env.TRELLO_API_KEY;
     const token = process.env.TRELLO_TOKEN;
     const defaultBoardId = process.env.TRELLO_BOARD_ID;
+    const allowedWorkspacesEnv = process.env.TRELLO_ALLOWED_WORKSPACES;
 
     if (!apiKey || !token) {
       throw new Error('TRELLO_API_KEY and TRELLO_TOKEN environment variables are required');
     }
+
+    // Parse allowed workspaces from comma-separated string
+    const allowedWorkspaceIds = allowedWorkspacesEnv
+      ? allowedWorkspacesEnv.split(',').map(id => id.trim()).filter(id => id.length > 0)
+      : undefined;
 
     this.trelloClient = new TrelloClient({
       apiKey,
       token,
       defaultBoardId,
       boardId: defaultBoardId,
+      allowedWorkspaceIds,
     });
 
     this.healthEndpoints = new TrelloHealthEndpoints(this.trelloClient);

--- a/src/index.ts
+++ b/src/index.ts
@@ -651,7 +651,8 @@ class TrelloServer {
       'list_workspaces',
       {
         title: 'List Workspaces',
-        description: 'List all workspaces the user has access to',
+        description:
+          'List workspaces the user has access to. If TRELLO_ALLOWED_WORKSPACES is configured, only allowed workspaces are returned.',
         inputSchema: {},
       },
       async () => {

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -47,12 +47,10 @@ export class TrelloClient {
   private rateLimiter;
   private defaultBoardId?: string;
   private activeConfig: TrelloConfig;
-  private allowedWorkspaceIds?: string[];
 
   constructor(private config: TrelloConfig) {
     this.defaultBoardId = config.defaultBoardId;
     this.activeConfig = { ...config };
-    this.allowedWorkspaceIds = config.allowedWorkspaceIds;
     // If boardId is provided in config, use it as the active board
     if (config.boardId && !this.activeConfig.boardId) {
       this.activeConfig.boardId = config.boardId;
@@ -147,7 +145,7 @@ export class TrelloClient {
    * Check if workspace restriction is enabled
    */
   get hasWorkspaceRestriction(): boolean {
-    return this.allowedWorkspaceIds !== undefined && this.allowedWorkspaceIds.length > 0;
+    return this.config.allowedWorkspaceIds !== undefined && this.config.allowedWorkspaceIds.length > 0;
   }
 
   /**
@@ -157,7 +155,7 @@ export class TrelloClient {
     if (!this.hasWorkspaceRestriction) {
       return true;
     }
-    return this.allowedWorkspaceIds!.includes(workspaceId);
+    return this.config.allowedWorkspaceIds!.includes(workspaceId);
   }
 
   /**
@@ -167,7 +165,7 @@ export class TrelloClient {
     if (!this.isWorkspaceAllowed(workspaceId)) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Access to workspace '${workspaceId}' is not allowed. Allowed workspaces: ${this.allowedWorkspaceIds!.join(', ')}`
+        `Access to workspace '${workspaceId}' is not allowed. Allowed workspaces: ${this.config.allowedWorkspaceIds!.join(', ')}`
       );
     }
   }
@@ -235,7 +233,7 @@ export class TrelloClient {
 
       // Filter by allowed workspaces if restriction is enabled
       if (this.hasWorkspaceRestriction) {
-        return boards.filter(board => this.isWorkspaceAllowed(board.idOrganization));
+        return boards.filter(board => board.idOrganization && this.isWorkspaceAllowed(board.idOrganization));
       }
       return boards;
     });
@@ -306,8 +304,14 @@ export class TrelloClient {
     // Determine the target workspace
     const targetWorkspace = params.idOrganization ?? this.activeConfig.workspaceId;
 
-    // Validate workspace access if a workspace is specified and restrictions are enabled
-    if (targetWorkspace && this.hasWorkspaceRestriction) {
+    // When workspace restrictions are enabled, require a valid workspace
+    if (this.hasWorkspaceRestriction) {
+      if (!targetWorkspace) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Workspace restrictions are enabled but no workspace was specified. Provide idOrganization or set an active workspace. Allowed workspaces: ${this.config.allowedWorkspaceIds!.join(', ')}`
+        );
+      }
       this.validateWorkspaceAccess(targetWorkspace);
     }
 

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -47,10 +47,12 @@ export class TrelloClient {
   private rateLimiter;
   private defaultBoardId?: string;
   private activeConfig: TrelloConfig;
+  private allowedWorkspaceIds?: string[];
 
   constructor(private config: TrelloConfig) {
     this.defaultBoardId = config.defaultBoardId;
     this.activeConfig = { ...config };
+    this.allowedWorkspaceIds = config.allowedWorkspaceIds;
     // If boardId is provided in config, use it as the active board
     if (config.boardId && !this.activeConfig.boardId) {
       this.activeConfig.boardId = config.boardId;
@@ -142,6 +144,35 @@ export class TrelloClient {
   }
 
   /**
+   * Check if workspace restriction is enabled
+   */
+  get hasWorkspaceRestriction(): boolean {
+    return this.allowedWorkspaceIds !== undefined && this.allowedWorkspaceIds.length > 0;
+  }
+
+  /**
+   * Check if a workspace ID is in the allowed list (or if no restriction is set)
+   */
+  isWorkspaceAllowed(workspaceId: string): boolean {
+    if (!this.hasWorkspaceRestriction) {
+      return true;
+    }
+    return this.allowedWorkspaceIds!.includes(workspaceId);
+  }
+
+  /**
+   * Validate workspace access, throwing an error if restricted
+   */
+  private validateWorkspaceAccess(workspaceId: string): void {
+    if (!this.isWorkspaceAllowed(workspaceId)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Access to workspace '${workspaceId}' is not allowed. Allowed workspaces: ${this.allowedWorkspaceIds!.join(', ')}`
+      );
+    }
+  }
+
+  /**
    * Set the active board
    */
   async setActiveBoard(boardId: string): Promise<TrelloBoard> {
@@ -154,8 +185,12 @@ export class TrelloClient {
 
   /**
    * Set the active workspace
+   * Validates against allowedWorkspaceIds if configured
    */
   async setActiveWorkspace(workspaceId: string): Promise<TrelloWorkspace> {
+    // Validate workspace access before proceeding
+    this.validateWorkspaceAccess(workspaceId);
+
     // Verify the workspace exists
     const workspace = await this.getWorkspaceById(workspaceId);
     this.activeConfig.workspaceId = workspaceId;
@@ -191,11 +226,18 @@ export class TrelloClient {
 
   /**
    * List all boards the user has access to
+   * If allowedWorkspaceIds is configured, only returns boards from allowed workspaces
    */
   async listBoards(): Promise<TrelloBoard[]> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/members/me/boards');
-      return response.data;
+      const boards: TrelloBoard[] = response.data;
+
+      // Filter by allowed workspaces if restriction is enabled
+      if (this.hasWorkspaceRestriction) {
+        return boards.filter(board => this.isWorkspaceAllowed(board.idOrganization));
+      }
+      return boards;
     });
   }
 
@@ -211,11 +253,18 @@ export class TrelloClient {
 
   /**
    * List all workspaces the user has access to
+   * If allowedWorkspaceIds is configured, only returns workspaces in that list
    */
   async listWorkspaces(): Promise<TrelloWorkspace[]> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/members/me/organizations');
-      return response.data;
+      const workspaces: TrelloWorkspace[] = response.data;
+
+      // Filter by allowed workspaces if restriction is enabled
+      if (this.hasWorkspaceRestriction) {
+        return workspaces.filter(ws => this.isWorkspaceAllowed(ws.id));
+      }
+      return workspaces;
     });
   }
 
@@ -231,8 +280,12 @@ export class TrelloClient {
 
   /**
    * List boards in a specific workspace
+   * Validates against allowedWorkspaceIds if configured
    */
   async listBoardsInWorkspace(workspaceId: string): Promise<TrelloBoard[]> {
+    // Validate workspace access before proceeding
+    this.validateWorkspaceAccess(workspaceId);
+
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get(`/organizations/${workspaceId}/boards`);
       return response.data;
@@ -241,6 +294,7 @@ export class TrelloClient {
 
   /**
    * Create a new board
+   * Validates target workspace against allowedWorkspaceIds if configured
    */
   async createBoard(params: {
     name: string;
@@ -249,11 +303,19 @@ export class TrelloClient {
     defaultLabels?: boolean;
     defaultLists?: boolean;
   }): Promise<TrelloBoard> {
+    // Determine the target workspace
+    const targetWorkspace = params.idOrganization ?? this.activeConfig.workspaceId;
+
+    // Validate workspace access if a workspace is specified and restrictions are enabled
+    if (targetWorkspace && this.hasWorkspaceRestriction) {
+      this.validateWorkspaceAccess(targetWorkspace);
+    }
+
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.post('/boards', {
         name: params.name,
         desc: params.desc,
-        idOrganization: params.idOrganization ?? this.activeConfig.workspaceId,
+        idOrganization: targetWorkspace,
         defaultLabels: params.defaultLabels,
         defaultLists: params.defaultLists,
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export interface TrelloConfig {
   defaultBoardId?: string;
   boardId?: string;
   workspaceId?: string;
+  /** Optional list of workspace IDs to restrict access to. If set, only these workspaces can be accessed. */
+  allowedWorkspaceIds?: string[];
 }
 
 export interface TrelloBoard {

--- a/tests/unit/trello-client.test.ts
+++ b/tests/unit/trello-client.test.ts
@@ -42,12 +42,17 @@ vi.mock('fs/promises', () => ({
   access: vi.fn(async () => {}),
 }));
 
-function createClient(overrides?: { boardId?: string; defaultBoardId?: string }) {
+function createClient(overrides?: {
+  boardId?: string;
+  defaultBoardId?: string;
+  allowedWorkspaceIds?: string[];
+}) {
   return new TrelloClient({
     apiKey: 'test-key',
     token: 'test-token',
     boardId: overrides?.boardId,
     defaultBoardId: overrides?.defaultBoardId,
+    allowedWorkspaceIds: overrides?.allowedWorkspaceIds,
   });
 }
 
@@ -65,6 +70,22 @@ describe('TrelloClient', () => {
           params: { key: 'test-key', token: 'test-token' },
         })
       );
+    });
+
+    it('should not enable workspace restrictions when allowed workspaces are unset or empty', () => {
+      expect(createClient().hasWorkspaceRestriction).toBe(false);
+      expect(createClient({ allowedWorkspaceIds: [] }).hasWorkspaceRestriction).toBe(false);
+    });
+  });
+
+  describe('workspace restriction', () => {
+    it('should reject access to a non-allowed workspace before making a request', async () => {
+      const client = createClient({ allowedWorkspaceIds: ['allowed-workspace'] });
+
+      await expect(client.listBoardsInWorkspace('blocked-workspace')).rejects.toThrow(
+        "Access to workspace 'blocked-workspace' is not allowed"
+      );
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Add optional workspace access restriction via the `TRELLO_ALLOWED_WORKSPACES` environment variable. This allows administrators to limit which Trello workspaces can be accessed via MCP tools.

**Use cases:**
- **Security**: Limiting AI agent access to only approved workspaces
- **Multi-tenant setups**: Ensuring agents only access relevant workspaces  
- **Testing**: Isolating test environments from production data

## Changes

- Added `allowedWorkspaceIds?: string[]` to `TrelloConfig` interface
- Added workspace filtering/validation methods to `TrelloClient`:
  - `hasWorkspaceRestriction` getter
  - `isWorkspaceAllowed(workspaceId)` method
  - `validateWorkspaceAccess(workspaceId)` private method
- Modified these methods to enforce workspace restrictions:
  - `listWorkspaces()` - filters results to allowed workspaces only
  - `listBoards()` - filters boards by allowed workspaces
  - `setActiveWorkspace()` - validates workspace ID before setting
  - `listBoardsInWorkspace()` - validates workspace ID before fetching
  - `createBoard()` - validates target workspace before creating
- Parse `TRELLO_ALLOWED_WORKSPACES` env var (comma-separated) in `index.ts`
- Updated README with documentation

## Configuration

```bash
# Only allow access to specific workspaces (comma-separated IDs)
TRELLO_ALLOWED_WORKSPACES=workspace-id-1,workspace-id-2
```

If not set or empty, all workspaces the token has access to will be available (backwards compatible).

## Test plan

- [ ] Build project with `bun run build`
- [ ] Test with `TRELLO_ALLOWED_WORKSPACES` set to a single workspace ID
- [ ] Verify `list_workspaces` only returns the allowed workspace
- [ ] Verify `set_active_workspace` rejects non-allowed workspace IDs
- [ ] Verify `list_boards` only shows boards from allowed workspaces
- [ ] Test without `TRELLO_ALLOWED_WORKSPACES` to confirm backwards compatibility

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)