### PR TITLE
Add update_list_position tool to reorder lists on a board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **List Position Management**: `update_list_position(listId, position)` - Reorder lists on a board using Trello's fractional indexing ("top", "bottom", or a numeric position)
+
 ## [1.7.0] - 2025-12-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Update the position of a list on the board. Trello uses fractional indexing: eac
   name: 'update_list_position',
   arguments: {
     listId: string,              // ID of the list to reposition
-    position: string | number    // "top", "bottom", or a float (average of neighbors to insert between)
+    position: string             // "top", "bottom", or a positive numeric string (e.g. "1536")
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -528,6 +528,20 @@ Send a list to the archive.
 }
 ```
 
+### update\_list\_position
+
+Update the position of a list on the board. Trello uses fractional indexing: each list has a float position, and to place a list between two others, use the average of their positions (e.g., between pos 1024 and 2048, use 1536). Use `"top"`/`"bottom"` shortcuts to move to the edges.
+
+```typescript
+{
+  name: 'update_list_position',
+  arguments: {
+    listId: string,              // ID of the list to reposition
+    position: string | number    // "top", "bottom", or a float (average of neighbors to insert between)
+  }
+}
+```
+
 ### get\_my\_cards
 
 Fetch all cards assigned to the current user.

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,9 +331,9 @@ class TrelloServer {
           position: z
             .string()
             .refine(
-              (val) => val === 'top' || val === 'bottom' || !Number.isNaN(Number(val)),
+              (val) => val === 'top' || val === 'bottom' || Number(val) > 0,
               {
-                message: "Position must be 'top', 'bottom', or a numeric string.",
+                message: "Position must be 'top', 'bottom', or a positive numeric string.",
               }
             )
             .describe(
@@ -343,8 +343,7 @@ class TrelloServer {
       },
       async ({ listId, position }) => {
         try {
-          const numericPosition = Number(position);
-          const parsedPosition = Number.isNaN(numericPosition) ? position : numericPosition;
+          const parsedPosition = position === 'top' || position === 'bottom' ? position : Number(position);
           const list = await this.trelloClient.updateListPosition(listId, parsedPosition);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(list, null, 2) }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,9 +331,13 @@ class TrelloServer {
           position: z
             .string()
             .refine(
-              (val) => val === 'top' || val === 'bottom' || Number(val) > 0,
+              (val) => {
+                if (val === 'top' || val === 'bottom') return true;
+                const num = Number(val);
+                return num > 0 && isFinite(num);
+              },
               {
-                message: "Position must be 'top', 'bottom', or a positive numeric string.",
+                message: "Position must be 'top', 'bottom', or a positive finite numeric string.",
               }
             )
             .describe(

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,36 @@ class TrelloServer {
       }
     );
 
+    // Update list position
+    this.server.registerTool(
+      'update_list_position',
+      {
+        title: 'Update List Position',
+        description:
+          'Update the position of a list on the board. Trello uses fractional indexing: each list has a float position, and to place a list between two others, use the average of their positions (e.g., between pos 1024 and 2048, use 1536). Use "top"/"bottom" shortcuts to move to the edges.',
+        inputSchema: {
+          listId: z.string().describe('ID of the list to reposition'),
+          position: z
+            .string()
+            .describe(
+              'New position: "top" (move to leftmost), "bottom" (move to rightmost), or a numeric string (e.g. "1536"). To place between two lists, use the average of their pos values.'
+            ),
+        },
+      },
+      async ({ listId, position }) => {
+        try {
+          const numericPosition = Number(position);
+          const parsedPosition = Number.isNaN(numericPosition) ? position : numericPosition;
+          const list = await this.trelloClient.updateListPosition(listId, parsedPosition);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(list, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
     // Get cards assigned to current user
     this.server.registerTool(
       'get_my_cards',

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,12 @@ class TrelloServer {
           listId: z.string().describe('ID of the list to reposition'),
           position: z
             .string()
+            .refine(
+              (val) => val === 'top' || val === 'bottom' || !Number.isNaN(Number(val)),
+              {
+                message: "Position must be 'top', 'bottom', or a numeric string.",
+              }
+            )
             .describe(
               'New position: "top" (move to leftmost), "bottom" (move to rightmost), or a numeric string (e.g. "1536"). To place between two lists, use the average of their pos values.'
             ),

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -383,6 +383,18 @@ export class TrelloClient {
     });
   }
 
+  async updateListPosition(
+    listId: string,
+    position: string | number
+  ): Promise<TrelloList> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.put(`/lists/${listId}/pos`, {
+        value: position,
+      });
+      return response.data;
+    });
+  }
+
   async getMyCards(): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/members/me/cards');


### PR DESCRIPTION
## Summary

Adds an `update_list_position` tool that allows repositioning lists on a board using Trello's fractional indexing system.

Closes #63

## Changes

- New `updateListPosition(listId, position)` method in `TrelloClient`
- New `update_list_position` tool registration in `index.ts`
- Documentation in `README.md` and `CHANGELOG.md`

## Implementation Notes

- Follows the same pattern as `archive_list` (handleRequest + axiosInstance.put)
- Uses inline Zod schema, consistent with recent tools in the project
- No changes to `types.ts` — `TrelloList` already includes the `pos` field
- Position parameter accepts `"top"`, `"bottom"`, or a numeric string (parsed to number in the handler to match the Trello API contract)

## API Reference

https://developer.atlassian.com/cloud/trello/rest/api-group-lists/#api-lists-id-field-put

## Test Plan

- [X] `get_lists` — verify current list positions
- [X] `update_list_position` with `"top"` — moves list to leftmost
- [X] `update_list_position` with `"bottom"` — moves list to rightmost
- [X] `update_list_position` with a numeric value — places list between others
- [X] `get_lists` again — confirm order changed
- [X] `bun run build` — compiles without errors