### PR TITLE
Add copy_card, copy_checklist, and add_cards_to_list tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1291,7 +1291,7 @@ class TrelloServer {
                   .describe('Array of label IDs to apply to the card'),
               })
             )
-            .describe('Array of cards to create'),
+            .describe('Array of cards to create (max 50)'),
         },
       },
       async ({ listId, cards }) => {
@@ -1301,11 +1301,7 @@ class TrelloServer {
             content: [
               {
                 type: 'text' as const,
-                text: JSON.stringify(
-                  { created: results.length, cards: results },
-                  null,
-                  2
-                ),
+                text: JSON.stringify(results, null, 2),
               },
             ],
           };

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1068,6 +1068,79 @@ export class TrelloClient {
     });
   }
 
+  /**
+   * Copy a card (can copy across boards). Uses idCardSource to clone a card.
+   */
+  async copyCard(params: {
+    sourceCardId: string;
+    listId: string;
+    name?: string;
+    description?: string;
+    keepFromSource?: string;
+    pos?: string;
+  }): Promise<TrelloCard> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post('/cards', {
+        idCardSource: params.sourceCardId,
+        idList: params.listId,
+        name: params.name,
+        desc: params.description,
+        keepFromSource: params.keepFromSource || 'all',
+        pos: params.pos,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * Copy a checklist from one card to another (can copy across boards).
+   */
+  async copyChecklist(params: {
+    sourceChecklistId: string;
+    cardId: string;
+    name?: string;
+    pos?: string;
+  }): Promise<TrelloChecklist> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post('/checklists', {
+        idCard: params.cardId,
+        idChecklistSource: params.sourceChecklistId,
+        name: params.name,
+        pos: params.pos,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * Add multiple cards to a list. Trello has no native batch write endpoint,
+   * so this makes sequential POST /1/cards calls.
+   */
+  async batchAddCards(
+    listId: string,
+    cards: Array<{
+      name: string;
+      description?: string;
+      dueDate?: string;
+      start?: string;
+      labels?: string[];
+    }>
+  ): Promise<TrelloCard[]> {
+    const results: TrelloCard[] = [];
+    for (const card of cards) {
+      const result = await this.addCard(undefined, {
+        listId,
+        name: card.name,
+        description: card.description,
+        dueDate: card.dueDate,
+        start: card.start,
+        labels: card.labels,
+      });
+      results.push(result);
+    }
+    return results;
+  }
+
   // Card history method
   async getCardHistory(
     cardId: string,


### PR DESCRIPTION
## Summary
- **`copy_card`**: Duplicate a card to any list (including cross-board) using Trello's `idCardSource` API, with configurable `keepFromSource` properties (attachments, checklists, comments, labels, etc.)
- **`copy_checklist`**: Copy a checklist with all its items from one card to another (works cross-board) using `idChecklistSource` API
- **`add_cards_to_list`**: Create multiple cards in a single tool call with sequential API requests and automatic rate limiting

## Test plan
- [x] Verified all three tools against a live Trello board
- [x] `copy_card` copies card with all properties to same/different board
- [x] `copy_checklist` copies checklist with items to a different card
- [x] `add_cards_to_list` creates multiple cards in one call
- [x] Rate limiting handles batch creation gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)