### PR TITLE
Add comprehensive test suite with vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@delorenj/mcp-server-trello",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@delorenj/mcp-server-trello",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
@@ -28,7 +28,8 @@
         "eslint-plugin-prettier": "^5.5.4",
         "prettier": "^3.7.4",
         "terser": "^5.44.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
       },
       "engines": {
         "bun": ">=1.0.0"
@@ -946,10 +947,392 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/diff-match-patch": {
       "version": "1.0.36",
       "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
       "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1027,6 +1410,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1190,6 +1574,117 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1221,6 +1716,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1349,6 +1845,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1490,6 +1996,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1789,6 +2305,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1883,6 +2406,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1939,6 +2463,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2109,6 +2634,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2158,11 +2693,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3040,6 +3586,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3270,6 +3826,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3457,6 +4024,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3479,6 +4060,35 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3495,6 +4105,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3671,6 +4282,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/router": {
@@ -3882,6 +4538,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3902,6 +4565,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -3913,6 +4586,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3921,6 +4601,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3995,6 +4682,7 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -4025,6 +4713,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4142,6 +4906,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4205,6 +4970,204 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -4245,6 +5208,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4279,6 +5259,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -32,15 +32,16 @@
   },
   "devDependencies": {
     "@ai-sdk/openai": "^1.3.24",
-    "bun-types": "latest",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "bun-types": "latest",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.4",
     "prettier": "^3.7.4",
     "terser": "^5.44.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   },
   "files": [
     "build/**/*"
@@ -64,6 +65,10 @@
     "versionbump:patch": "bun run versionbump --patch",
     "versionbump:minor": "bun run versionbump --minor",
     "versionbump:major": "bun run versionbump --major",
+    "test": "vitest run",
+    "test:unit": "vitest run tests/unit",
+    "test:smoke": "vitest run tests/smoke",
+    "test:watch": "vitest",
     "publish": "bun run build && npm publish"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1291,7 +1291,7 @@ class TrelloServer {
                   .describe('Array of label IDs to apply to the card'),
               })
             )
-            .describe('Array of cards to create'),
+            .describe('Array of cards to create (max 50)'),
         },
       },
       async ({ listId, cards }) => {
@@ -1301,11 +1301,7 @@ class TrelloServer {
             content: [
               {
                 type: 'text' as const,
-                text: JSON.stringify(
-                  { created: results.length, cards: results },
-                  null,
-                  2
-                ),
+                text: JSON.stringify(results, null, 2),
               },
             ],
           };

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1068,6 +1068,79 @@ export class TrelloClient {
     });
   }
 
+  /**
+   * Copy a card (can copy across boards). Uses idCardSource to clone a card.
+   */
+  async copyCard(params: {
+    sourceCardId: string;
+    listId: string;
+    name?: string;
+    description?: string;
+    keepFromSource?: string;
+    pos?: string;
+  }): Promise<TrelloCard> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post('/cards', {
+        idCardSource: params.sourceCardId,
+        idList: params.listId,
+        name: params.name,
+        desc: params.description,
+        keepFromSource: params.keepFromSource || 'all',
+        pos: params.pos,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * Copy a checklist from one card to another (can copy across boards).
+   */
+  async copyChecklist(params: {
+    sourceChecklistId: string;
+    cardId: string;
+    name?: string;
+    pos?: string;
+  }): Promise<TrelloChecklist> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post('/checklists', {
+        idCard: params.cardId,
+        idChecklistSource: params.sourceChecklistId,
+        name: params.name,
+        pos: params.pos,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * Add multiple cards to a list. Trello has no native batch write endpoint,
+   * so this makes sequential POST /1/cards calls.
+   */
+  async batchAddCards(
+    listId: string,
+    cards: Array<{
+      name: string;
+      description?: string;
+      dueDate?: string;
+      start?: string;
+      labels?: string[];
+    }>
+  ): Promise<TrelloCard[]> {
+    const results: TrelloCard[] = [];
+    for (const card of cards) {
+      const result = await this.addCard(undefined, {
+        listId,
+        name: card.name,
+        description: card.description,
+        dueDate: card.dueDate,
+        start: card.start,
+        labels: card.labels,
+      });
+      results.push(result);
+    }
+    return results;
+  }
+
   // Card history method
   async getCardHistory(
     cardId: string,

--- a/tests/smoke/smoke.test.ts
+++ b/tests/smoke/smoke.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawn, ChildProcess } from 'child_process';
+import path from 'path';
+
+const TRELLO_API_KEY = process.env.TRELLO_API_KEY;
+const TRELLO_TOKEN = process.env.TRELLO_TOKEN;
+const TEST_BOARD_ID = process.env.TRELLO_TEST_BOARD_ID || '698bd319de70fa4f7a3c7ccd';
+
+const canRunSmoke = Boolean(TRELLO_API_KEY && TRELLO_TOKEN);
+
+/**
+ * Helper to communicate with the MCP server over stdio JSON-RPC.
+ */
+class McpTestClient {
+  private server: ChildProcess;
+  private buffer = '';
+  private requestId = 0;
+  private pending = new Map<number, (msg: any) => void>();
+
+  constructor() {
+    this.server = spawn('node', [path.resolve('build/index.js')], {
+      env: {
+        ...process.env,
+        TRELLO_API_KEY,
+        TRELLO_TOKEN,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    this.server.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString();
+      const lines = this.buffer.split('\n');
+      this.buffer = lines.pop()!;
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id && this.pending.has(msg.id)) {
+              this.pending.get(msg.id)!(msg);
+              this.pending.delete(msg.id);
+            }
+          } catch {
+            // ignore non-JSON lines
+          }
+        }
+      }
+    });
+  }
+
+  async initialize(): Promise<void> {
+    await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'smoke-test', version: '1.0.0' },
+    });
+    this.server.stdin!.write(
+      JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n'
+    );
+  }
+
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<any> {
+    const response = await this.request('tools/call', { name, arguments: args });
+    if (response.result?.isError) {
+      throw new Error(response.result.content[0]?.text || 'Tool call failed');
+    }
+    const text = response.result.content[0].text;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  private request(method: string, params: Record<string, unknown>): Promise<any> {
+    return new Promise((resolve) => {
+      const id = ++this.requestId;
+      this.pending.set(id, resolve);
+      this.server.stdin!.write(
+        JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'
+      );
+    });
+  }
+
+  close(): void {
+    this.server.kill();
+  }
+}
+
+describe.skipIf(!canRunSmoke)('Smoke Tests (Live Trello API)', () => {
+  let client: McpTestClient;
+  let testListId: string;
+
+  // Track created resources for cleanup
+  const createdCardIds: string[] = [];
+
+  beforeAll(async () => {
+    client = new McpTestClient();
+    await client.initialize();
+
+    // Ensure test list exists
+    const lists = await client.callTool('get_lists', { boardId: TEST_BOARD_ID });
+    if (lists.length > 0) {
+      testListId = lists[0].id;
+    } else {
+      const newList = await client.callTool('add_list_to_board', {
+        boardId: TEST_BOARD_ID,
+        name: 'Smoke Test List',
+      });
+      testListId = newList.id;
+    }
+  });
+
+  afterAll(async () => {
+    // Archive cards created during tests
+    for (const cardId of createdCardIds) {
+      try {
+        await client.callTool('archive_card', { cardId });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    client?.close();
+  });
+
+  describe('Board operations', () => {
+    it('should list boards', async () => {
+      const boards = await client.callTool('list_boards');
+      expect(Array.isArray(boards)).toBe(true);
+      expect(boards.length).toBeGreaterThan(0);
+      expect(boards[0]).toHaveProperty('id');
+      expect(boards[0]).toHaveProperty('name');
+    });
+
+    it('should get lists from test board', async () => {
+      const lists = await client.callTool('get_lists', { boardId: TEST_BOARD_ID });
+      expect(Array.isArray(lists)).toBe(true);
+      expect(lists.length).toBeGreaterThan(0);
+    });
+
+    it('should set and get active board', async () => {
+      const setResult = await client.callTool('set_active_board', { boardId: TEST_BOARD_ID });
+      expect(typeof setResult).toBe('string'); // returns plain text confirmation
+      const info = await client.callTool('get_active_board_info');
+      expect(info.id).toBe(TEST_BOARD_ID);
+    });
+  });
+
+  describe('Card CRUD', () => {
+    let cardId: string;
+
+    it('should create a card', async () => {
+      const card = await client.callTool('add_card_to_list', {
+        listId: testListId,
+        name: 'Smoke Test Card',
+        description: 'Created by smoke test',
+      });
+      expect(card).toHaveProperty('id');
+      expect(card.name).toBe('Smoke Test Card');
+      cardId = card.id;
+      createdCardIds.push(cardId);
+    });
+
+    it('should get card details', async () => {
+      const card = await client.callTool('get_card', { cardId });
+      expect(card.id).toBe(cardId);
+      expect(card.name).toBe('Smoke Test Card');
+      expect(card.desc).toBe('Created by smoke test');
+    });
+
+    it('should update card', async () => {
+      const updated = await client.callTool('update_card_details', {
+        cardId,
+        name: 'Updated Smoke Card',
+        description: 'Updated by smoke test',
+      });
+      expect(updated.name).toBe('Updated Smoke Card');
+    });
+
+    it('should get cards by list', async () => {
+      const cards = await client.callTool('get_cards_by_list_id', { listId: testListId });
+      expect(Array.isArray(cards)).toBe(true);
+      const found = cards.find((c: any) => c.id === cardId);
+      expect(found).toBeTruthy();
+    });
+
+    it('should archive card', async () => {
+      const archived = await client.callTool('archive_card', { cardId });
+      expect(archived.closed).toBe(true);
+      // Remove from cleanup since already archived
+      const idx = createdCardIds.indexOf(cardId);
+      if (idx > -1) createdCardIds.splice(idx, 1);
+    });
+  });
+
+  describe('Checklist operations', () => {
+    let cardId: string;
+    let checklistId: string;
+
+    beforeAll(async () => {
+      const card = await client.callTool('add_card_to_list', {
+        listId: testListId,
+        name: 'Checklist Test Card',
+      });
+      cardId = card.id;
+      createdCardIds.push(cardId);
+    });
+
+    it('should create a checklist', async () => {
+      const checklist = await client.callTool('create_checklist', {
+        cardId,
+        name: 'Test Checklist',
+      });
+      expect(checklist).toHaveProperty('id');
+      expect(checklist.name).toBe('Test Checklist');
+      checklistId = checklist.id;
+    });
+
+    it('should add items to checklist', async () => {
+      const item = await client.callTool('add_checklist_item', {
+        cardId,
+        checkListName: 'Test Checklist',
+        text: 'Test Item 1',
+      });
+      expect(item).toHaveProperty('id');
+      expect(item.text).toBe('Test Item 1');
+    });
+
+    it('should get checklist by name', async () => {
+      const checklist = await client.callTool('get_checklist_by_name', {
+        cardId,
+        name: 'Test Checklist',
+      });
+      expect(checklist.name).toBe('Test Checklist');
+      expect(checklist.items.length).toBeGreaterThan(0);
+    });
+
+    it('should get checklist items', async () => {
+      const items = await client.callTool('get_checklist_items', {
+        cardId,
+        name: 'Test Checklist',
+      });
+      expect(items.length).toBeGreaterThan(0);
+      expect(items[0]).toHaveProperty('text');
+    });
+  });
+
+  describe('Comment operations', () => {
+    let cardId: string;
+    let commentId: string;
+
+    beforeAll(async () => {
+      const card = await client.callTool('add_card_to_list', {
+        listId: testListId,
+        name: 'Comment Test Card',
+      });
+      cardId = card.id;
+      createdCardIds.push(cardId);
+    });
+
+    it('should add a comment', async () => {
+      const comment = await client.callTool('add_comment', {
+        cardId,
+        text: 'Smoke test comment',
+      });
+      expect(comment).toHaveProperty('id');
+      commentId = comment.id;
+    });
+
+    it('should get card comments', async () => {
+      const comments = await client.callTool('get_card_comments', { cardId });
+      expect(Array.isArray(comments)).toBe(true);
+      expect(comments.length).toBeGreaterThan(0);
+    });
+
+    it('should delete a comment', async () => {
+      const result = await client.callTool('delete_comment', { commentId });
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('copy_card', () => {
+    let sourceCardId: string;
+
+    beforeAll(async () => {
+      const card = await client.callTool('add_card_to_list', {
+        listId: testListId,
+        name: 'Copy Source Card',
+        description: 'This card will be copied',
+      });
+      sourceCardId = card.id;
+      createdCardIds.push(sourceCardId);
+    });
+
+    it('should copy a card with all properties', async () => {
+      const copied = await client.callTool('copy_card', {
+        sourceCardId,
+        listId: testListId,
+        keepFromSource: 'all',
+      });
+      expect(copied).toHaveProperty('id');
+      expect(copied.id).not.toBe(sourceCardId);
+      expect(copied.name).toBe('Copy Source Card');
+      createdCardIds.push(copied.id);
+    });
+
+    it('should copy a card with custom name', async () => {
+      const copied = await client.callTool('copy_card', {
+        sourceCardId,
+        listId: testListId,
+        name: 'Renamed Copy',
+      });
+      expect(copied.name).toBe('Renamed Copy');
+      createdCardIds.push(copied.id);
+    });
+
+    it('should copy with selective keepFromSource', async () => {
+      const copied = await client.callTool('copy_card', {
+        sourceCardId,
+        listId: testListId,
+        keepFromSource: 'due,labels',
+      });
+      expect(copied).toHaveProperty('id');
+      createdCardIds.push(copied.id);
+    });
+  });
+
+  describe('copy_checklist', () => {
+    let sourceCardId: string;
+    let destCardId: string;
+    let checklistId: string;
+
+    beforeAll(async () => {
+      const [srcCard, dstCard] = await Promise.all([
+        client.callTool('add_card_to_list', {
+          listId: testListId,
+          name: 'Checklist Copy Source',
+        }),
+        client.callTool('add_card_to_list', {
+          listId: testListId,
+          name: 'Checklist Copy Dest',
+        }),
+      ]);
+      sourceCardId = srcCard.id;
+      destCardId = dstCard.id;
+      createdCardIds.push(sourceCardId, destCardId);
+
+      // Create checklist with items on source
+      const cl = await client.callTool('create_checklist', {
+        cardId: sourceCardId,
+        name: 'Source Checklist',
+      });
+      checklistId = cl.id;
+
+      await client.callTool('add_checklist_item', {
+        cardId: sourceCardId,
+        checkListName: 'Source Checklist',
+        text: 'Item A',
+      });
+      await client.callTool('add_checklist_item', {
+        cardId: sourceCardId,
+        checkListName: 'Source Checklist',
+        text: 'Item B',
+      });
+    });
+
+    it('should copy checklist to another card', async () => {
+      const copied = await client.callTool('copy_checklist', {
+        sourceChecklistId: checklistId,
+        cardId: destCardId,
+      });
+      expect(copied).toHaveProperty('id');
+      expect(copied.id).not.toBe(checklistId);
+      expect(copied.name).toBe('Source Checklist');
+      expect(copied.checkItems).toHaveLength(2);
+    });
+
+    it('should copy checklist with custom name', async () => {
+      const copied = await client.callTool('copy_checklist', {
+        sourceChecklistId: checklistId,
+        cardId: destCardId,
+        name: 'Renamed Checklist',
+      });
+      expect(copied.name).toBe('Renamed Checklist');
+    });
+  });
+
+  describe('add_cards_to_list', () => {
+    it('should create multiple cards', async () => {
+      const result = await client.callTool('add_cards_to_list', {
+        listId: testListId,
+        cards: [
+          { name: 'Batch 1', description: 'First' },
+          { name: 'Batch 2', description: 'Second' },
+          { name: 'Batch 3' },
+        ],
+      });
+      expect(result.created).toBe(3);
+      expect(result.cards).toHaveLength(3);
+      expect(result.cards[0].name).toBe('Batch 1');
+      expect(result.cards[1].name).toBe('Batch 2');
+      expect(result.cards[2].name).toBe('Batch 3');
+      result.cards.forEach((c: any) => createdCardIds.push(c.id));
+    });
+
+    it('should handle single card in batch', async () => {
+      const result = await client.callTool('add_cards_to_list', {
+        listId: testListId,
+        cards: [{ name: 'Single Batch Card' }],
+      });
+      expect(result.created).toBe(1);
+      createdCardIds.push(result.cards[0].id);
+    });
+  });
+
+  describe('Label operations', () => {
+    let labelId: string;
+
+    it('should get board labels', async () => {
+      const labels = await client.callTool('get_board_labels', { boardId: TEST_BOARD_ID });
+      expect(Array.isArray(labels)).toBe(true);
+    });
+
+    it('should create a label', async () => {
+      const label = await client.callTool('create_label', {
+        boardId: TEST_BOARD_ID,
+        name: 'Smoke Test Label',
+        color: 'green',
+      });
+      expect(label).toHaveProperty('id');
+      expect(label.name).toBe('Smoke Test Label');
+      labelId = label.id;
+    });
+
+    it('should update a label', async () => {
+      const updated = await client.callTool('update_label', {
+        labelId,
+        name: 'Updated Label',
+        color: 'blue',
+      });
+      expect(updated.name).toBe('Updated Label');
+    });
+
+    it('should delete a label', async () => {
+      const result = await client.callTool('delete_label', { labelId });
+      expect(result).toBe('Label deleted successfully');
+    });
+  });
+});

--- a/tests/smoke/smoke.test.ts
+++ b/tests/smoke/smoke.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 
 const TRELLO_API_KEY = process.env.TRELLO_API_KEY;
 const TRELLO_TOKEN = process.env.TRELLO_TOKEN;
-const TEST_BOARD_ID = process.env.TRELLO_TEST_BOARD_ID || '698bd319de70fa4f7a3c7ccd';
+const TEST_BOARD_ID = process.env.TRELLO_TEST_BOARD_ID;
 
-const canRunSmoke = Boolean(TRELLO_API_KEY && TRELLO_TOKEN);
+const canRunSmoke = Boolean(TRELLO_API_KEY && TRELLO_TOKEN && TEST_BOARD_ID);
 
 /**
  * Helper to communicate with the MCP server over stdio JSON-RPC.
@@ -394,12 +394,12 @@ describe.skipIf(!canRunSmoke)('Smoke Tests (Live Trello API)', () => {
           { name: 'Batch 3' },
         ],
       });
-      expect(result.created).toBe(3);
-      expect(result.cards).toHaveLength(3);
-      expect(result.cards[0].name).toBe('Batch 1');
-      expect(result.cards[1].name).toBe('Batch 2');
-      expect(result.cards[2].name).toBe('Batch 3');
-      result.cards.forEach((c: any) => createdCardIds.push(c.id));
+      expect(result.created).toHaveLength(3);
+      expect(result.errors).toHaveLength(0);
+      expect(result.created[0].name).toBe('Batch 1');
+      expect(result.created[1].name).toBe('Batch 2');
+      expect(result.created[2].name).toBe('Batch 3');
+      result.created.forEach((c: any) => createdCardIds.push(c.id));
     });
 
     it('should handle single card in batch', async () => {
@@ -407,8 +407,8 @@ describe.skipIf(!canRunSmoke)('Smoke Tests (Live Trello API)', () => {
         listId: testListId,
         cards: [{ name: 'Single Batch Card' }],
       });
-      expect(result.created).toBe(1);
-      createdCardIds.push(result.cards[0].id);
+      expect(result.created).toHaveLength(1);
+      createdCardIds.push(result.created[0].id);
     });
   });
 

--- a/tests/unit/rate-limiter.test.ts
+++ b/tests/unit/rate-limiter.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenBucketRateLimiter, createTrelloRateLimiters } from '../../src/rate-limiter.js';
+
+describe('TokenBucketRateLimiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with full tokens', () => {
+      const limiter = new TokenBucketRateLimiter(10, 1000);
+      // Should be able to make 10 requests immediately
+      for (let i = 0; i < 10; i++) {
+        expect(limiter.canMakeRequest()).toBe(true);
+      }
+    });
+
+    it('should deny requests when tokens are exhausted', () => {
+      const limiter = new TokenBucketRateLimiter(3, 1000);
+      expect(limiter.canMakeRequest()).toBe(true);
+      expect(limiter.canMakeRequest()).toBe(true);
+      expect(limiter.canMakeRequest()).toBe(true);
+      expect(limiter.canMakeRequest()).toBe(false);
+    });
+  });
+
+  describe('canMakeRequest', () => {
+    it('should consume exactly one token per call', () => {
+      const limiter = new TokenBucketRateLimiter(5, 1000);
+      let count = 0;
+      while (limiter.canMakeRequest()) {
+        count++;
+      }
+      expect(count).toBe(5);
+    });
+
+    it('should refill tokens over time', () => {
+      const limiter = new TokenBucketRateLimiter(10, 1000);
+      // Exhaust all tokens
+      for (let i = 0; i < 10; i++) {
+        limiter.canMakeRequest();
+      }
+      expect(limiter.canMakeRequest()).toBe(false);
+
+      // Advance time by 500ms (should refill ~5 tokens for 10/1000ms rate)
+      vi.advanceTimersByTime(500);
+      expect(limiter.canMakeRequest()).toBe(true);
+    });
+
+    it('should not exceed maxTokens when refilling', () => {
+      const limiter = new TokenBucketRateLimiter(5, 1000);
+      // Don't use any tokens, advance time far ahead
+      vi.advanceTimersByTime(10000);
+      // Should still only have 5 tokens max
+      let count = 0;
+      while (limiter.canMakeRequest()) {
+        count++;
+      }
+      expect(count).toBe(5);
+    });
+
+    it('should refill at the correct rate', () => {
+      const limiter = new TokenBucketRateLimiter(100, 10000); // 100 per 10s = 10/s
+      // Exhaust all tokens
+      for (let i = 0; i < 100; i++) {
+        limiter.canMakeRequest();
+      }
+      // Advance 1 second - should have ~10 tokens
+      vi.advanceTimersByTime(1000);
+      let count = 0;
+      while (limiter.canMakeRequest()) {
+        count++;
+      }
+      expect(count).toBe(10);
+    });
+  });
+
+  describe('waitForAvailableToken', () => {
+    it('should resolve immediately when tokens are available', async () => {
+      const limiter = new TokenBucketRateLimiter(10, 1000);
+      await limiter.waitForAvailableToken();
+      // If we got here, it resolved
+      expect(true).toBe(true);
+    });
+
+    it('should wait and resolve when tokens become available', async () => {
+      const limiter = new TokenBucketRateLimiter(1, 1000);
+      // Exhaust the one token
+      limiter.canMakeRequest();
+
+      let resolved = false;
+      const promise = limiter.waitForAvailableToken().then(() => {
+        resolved = true;
+      });
+
+      expect(resolved).toBe(false);
+
+      // Advance time to allow refill
+      vi.advanceTimersByTime(1100);
+      await promise;
+      expect(resolved).toBe(true);
+    });
+  });
+});
+
+describe('createTrelloRateLimiters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should create limiters with correct Trello limits', () => {
+    const limiters = createTrelloRateLimiters();
+    expect(limiters).toHaveProperty('apiKeyLimiter');
+    expect(limiters).toHaveProperty('tokenLimiter');
+    expect(limiters).toHaveProperty('canMakeRequest');
+    expect(limiters).toHaveProperty('waitForAvailableToken');
+  });
+
+  it('should respect the token limiter (100 per 10s) as the tighter constraint', () => {
+    const limiters = createTrelloRateLimiters();
+    // The token limiter is 100 per 10s, API key is 300 per 10s
+    // After 100 requests, canMakeRequest should return false (token limiter exhausted)
+    for (let i = 0; i < 100; i++) {
+      expect(limiters.canMakeRequest()).toBe(true);
+    }
+    expect(limiters.canMakeRequest()).toBe(false);
+  });
+
+  it('canMakeRequest consumes tokens from both limiters', () => {
+    const limiters = createTrelloRateLimiters();
+    // Make 100 requests (exhausts token limiter)
+    for (let i = 0; i < 100; i++) {
+      limiters.canMakeRequest();
+    }
+    // Wait for token limiter to refill but API key limiter still has tokens
+    vi.advanceTimersByTime(10000);
+    // Should work again
+    expect(limiters.canMakeRequest()).toBe(true);
+  });
+
+  it('waitForAvailableToken waits for both limiters', async () => {
+    const limiters = createTrelloRateLimiters();
+    // Exhaust token limiter
+    for (let i = 0; i < 100; i++) {
+      limiters.canMakeRequest();
+    }
+
+    let resolved = false;
+    const promise = limiters.waitForAvailableToken().then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+    vi.advanceTimersByTime(1100);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});

--- a/tests/unit/trello-client.test.ts
+++ b/tests/unit/trello-client.test.ts
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { TrelloClient } from '../../src/trello-client.js';
+
+// Shared mock instance that axios.create will return
+const mockAxiosInstance = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  interceptors: {
+    request: { use: vi.fn() },
+    response: { use: vi.fn() },
+  },
+};
+
+// Mock axios
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => mockAxiosInstance),
+    isAxiosError: vi.fn(() => false),
+  },
+}));
+
+// Mock rate-limiter
+vi.mock('../../src/rate-limiter.js', () => ({
+  createTrelloRateLimiters: () => ({
+    apiKeyLimiter: { canMakeRequest: () => true, waitForAvailableToken: async () => {} },
+    tokenLimiter: { canMakeRequest: () => true, waitForAvailableToken: async () => {} },
+    canMakeRequest: () => true,
+    waitForAvailableToken: async () => {},
+  }),
+}));
+
+// Mock fs/promises for config loading
+vi.mock('fs/promises', () => ({
+  mkdir: vi.fn(async () => {}),
+  readFile: vi.fn(async () => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+}));
+
+function createClient(overrides?: { boardId?: string; defaultBoardId?: string }) {
+  return new TrelloClient({
+    apiKey: 'test-key',
+    token: 'test-token',
+    boardId: overrides?.boardId,
+    defaultBoardId: overrides?.defaultBoardId,
+  });
+}
+
+describe('TrelloClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create axios instance with correct base URL and auth', () => {
+      createClient();
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.trello.com/1',
+          params: { key: 'test-key', token: 'test-token' },
+        })
+      );
+    });
+  });
+
+  describe('listBoards', () => {
+    it('should fetch user boards', async () => {
+      const boards = [{ id: 'b1', name: 'Board 1' }];
+      mockAxiosInstance.get.mockResolvedValue({ data: boards });
+
+      const client = createClient();
+      const result = await client.listBoards();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/members/me/boards');
+      expect(result).toEqual(boards);
+    });
+  });
+
+  describe('getBoardById', () => {
+    it('should fetch a specific board', async () => {
+      const board = { id: 'b1', name: 'Test Board' };
+      mockAxiosInstance.get.mockResolvedValue({ data: board });
+
+      const client = createClient();
+      const result = await client.getBoardById('b1');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/boards/b1');
+      expect(result).toEqual(board);
+    });
+  });
+
+  describe('getLists', () => {
+    it('should use provided boardId', async () => {
+      const lists = [{ id: 'l1', name: 'List 1' }];
+      mockAxiosInstance.get.mockResolvedValue({ data: lists });
+
+      const client = createClient();
+      const result = await client.getLists('board123');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/boards/board123/lists');
+      expect(result).toEqual(lists);
+    });
+
+    it('should fall back to active board', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient({ boardId: 'active-board' });
+      await client.getLists();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/boards/active-board/lists');
+    });
+
+    it('should throw when no board ID available', async () => {
+      const client = createClient();
+      await expect(client.getLists()).rejects.toThrow(
+        'boardId is required when no default board is configured'
+      );
+    });
+  });
+
+  describe('addCard', () => {
+    it('should create card with all parameters', async () => {
+      const card = { id: 'c1', name: 'New Card' };
+      mockAxiosInstance.post.mockResolvedValue({ data: card });
+
+      const client = createClient();
+      const result = await client.addCard(undefined, {
+        listId: 'l1',
+        name: 'New Card',
+        description: 'A description',
+        dueDate: '2024-12-31T00:00:00Z',
+        start: '2024-12-01',
+        labels: ['label1'],
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards', {
+        idList: 'l1',
+        name: 'New Card',
+        desc: 'A description',
+        due: '2024-12-31T00:00:00Z',
+        start: '2024-12-01',
+        idLabels: ['label1'],
+      });
+      expect(result).toEqual(card);
+    });
+
+    it('should create card with minimal parameters', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'c1' } });
+
+      const client = createClient();
+      await client.addCard(undefined, { listId: 'l1', name: 'Card' });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards', {
+        idList: 'l1',
+        name: 'Card',
+        desc: undefined,
+        due: undefined,
+        start: undefined,
+        idLabels: undefined,
+      });
+    });
+  });
+
+  describe('updateCard', () => {
+    it('should update card fields', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'c1', name: 'Updated' } });
+
+      const client = createClient();
+      await client.updateCard(undefined, {
+        cardId: 'c1',
+        name: 'Updated',
+        dueComplete: true,
+      });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/cards/c1', {
+        name: 'Updated',
+        desc: undefined,
+        due: undefined,
+        start: undefined,
+        dueComplete: true,
+        idLabels: undefined,
+      });
+    });
+  });
+
+  describe('archiveCard', () => {
+    it('should set closed to true', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'c1', closed: true } });
+
+      const client = createClient();
+      await client.archiveCard(undefined, 'c1');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/cards/c1', { closed: true });
+    });
+  });
+
+  describe('moveCard', () => {
+    it('should update card list', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'c1' } });
+
+      const client = createClient();
+      await client.moveCard(undefined, 'c1', 'l2');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/cards/c1', { idList: 'l2' });
+    });
+
+    it('should include boardId when provided', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'c1' } });
+
+      const client = createClient({ defaultBoardId: 'b1' });
+      await client.moveCard('b2', 'c1', 'l2');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/cards/c1', {
+        idList: 'l2',
+        idBoard: 'b2',
+      });
+    });
+  });
+
+  describe('addList', () => {
+    it('should create list on board', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'l1', name: 'New List' } });
+
+      const client = createClient({ boardId: 'b1' });
+      await client.addList(undefined, 'New List');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/lists', {
+        name: 'New List',
+        idBoard: 'b1',
+      });
+    });
+
+    it('should throw when no board ID available', async () => {
+      const client = createClient();
+      await expect(client.addList(undefined, 'List')).rejects.toThrow(
+        'boardId is required'
+      );
+    });
+  });
+
+  describe('archiveList', () => {
+    it('should set list closed value to true', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'l1' } });
+
+      const client = createClient();
+      await client.archiveList(undefined, 'l1');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/lists/l1/closed', { value: true });
+    });
+  });
+
+  describe('getMyCards', () => {
+    it('should fetch current user cards', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient();
+      await client.getMyCards();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/members/me/cards');
+    });
+  });
+
+  describe('Comments', () => {
+    it('addCommentToCard should post comment', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'comment1' } });
+
+      const client = createClient();
+      await client.addCommentToCard('c1', 'Hello');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        'cards/c1/actions/comments?text=Hello'
+      );
+    });
+
+    it('addCommentToCard should encode special characters', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'comment1' } });
+
+      const client = createClient();
+      await client.addCommentToCard('c1', 'Hello World & Test');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        'cards/c1/actions/comments?text=Hello%20World%20%26%20Test'
+      );
+    });
+
+    it('updateCommentOnCard should return true on success', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ status: 200, data: {} });
+
+      const client = createClient();
+      const result = await client.updateCommentOnCard('comment1', 'Updated text');
+
+      expect(result).toBe(true);
+    });
+
+    it('updateCommentOnCard should return false on non-200', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ status: 201, data: {} });
+
+      const client = createClient();
+      const result = await client.updateCommentOnCard('comment1', 'Text');
+
+      expect(result).toBe(false);
+    });
+
+    it('deleteCommentFromCard should call delete', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({ status: 200 });
+
+      const client = createClient();
+      await client.deleteCommentFromCard('comment1');
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/actions/comment1');
+    });
+
+    it('getCardComments should fetch with filter and limit', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient();
+      await client.getCardComments('c1', 50);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/cards/c1/actions', {
+        params: { filter: 'commentCard', limit: 50 },
+      });
+    });
+  });
+
+  describe('Checklists', () => {
+    it('createChecklist should post to card', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'cl1', name: 'Checklist' } });
+
+      const client = createClient();
+      await client.createChecklist('My Checklist', 'c1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards/c1/checklists', {
+        name: 'My Checklist',
+      });
+    });
+
+    it('createChecklist should throw when no cardId', async () => {
+      const client = createClient();
+      await expect(client.createChecklist('Name', '')).rejects.toThrow('No card ID provided');
+    });
+
+    it('updateChecklistItem should update state', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'ci1', state: 'complete' } });
+
+      const client = createClient();
+      await client.updateChecklistItem('c1', 'ci1', 'complete');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/cards/c1/checkItem/ci1', {
+        state: 'complete',
+      });
+    });
+  });
+
+  describe('Members', () => {
+    it('getBoardMembers should fetch members', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient({ boardId: 'b1' });
+      await client.getBoardMembers();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/boards/b1/members');
+    });
+
+    it('assignMemberToCard should post member', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'c1' } });
+
+      const client = createClient();
+      await client.assignMemberToCard('c1', 'm1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards/c1/idMembers', { value: 'm1' });
+    });
+
+    it('removeMemberFromCard should delete member', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({ data: [] });
+
+      const client = createClient();
+      await client.removeMemberFromCard('c1', 'm1');
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/cards/c1/idMembers/m1');
+    });
+  });
+
+  describe('Labels', () => {
+    it('createLabel should post to board', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'lbl1' } });
+
+      const client = createClient({ boardId: 'b1' });
+      await client.createLabel(undefined, 'Bug', 'red');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/boards/b1/labels', {
+        name: 'Bug',
+        color: 'red',
+      });
+    });
+
+    it('updateLabel should put with provided fields', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'lbl1' } });
+
+      const client = createClient();
+      await client.updateLabel('lbl1', 'New Name', 'blue');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/labels/lbl1', {
+        name: 'New Name',
+        color: 'blue',
+      });
+    });
+
+    it('updateLabel should only include defined fields', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: { id: 'lbl1' } });
+
+      const client = createClient();
+      await client.updateLabel('lbl1', 'Name');
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/labels/lbl1', { name: 'Name' });
+    });
+
+    it('deleteLabel should call delete', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({});
+
+      const client = createClient();
+      await client.deleteLabel('lbl1');
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/labels/lbl1');
+    });
+  });
+
+  describe('copyCard', () => {
+    it('should post with idCardSource and keepFromSource=all by default', async () => {
+      const copiedCard = { id: 'c2', name: 'Copied Card' };
+      mockAxiosInstance.post.mockResolvedValue({ data: copiedCard });
+
+      const client = createClient();
+      const result = await client.copyCard({
+        sourceCardId: 'c1',
+        listId: 'l1',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards', {
+        idCardSource: 'c1',
+        idList: 'l1',
+        name: undefined,
+        desc: undefined,
+        keepFromSource: 'all',
+        pos: undefined,
+      });
+      expect(result).toEqual(copiedCard);
+    });
+
+    it('should allow overriding name and keepFromSource', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'c2' } });
+
+      const client = createClient();
+      await client.copyCard({
+        sourceCardId: 'c1',
+        listId: 'l1',
+        name: 'Custom Name',
+        keepFromSource: 'checklists,labels',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/cards', {
+        idCardSource: 'c1',
+        idList: 'l1',
+        name: 'Custom Name',
+        desc: undefined,
+        keepFromSource: 'checklists,labels',
+        pos: undefined,
+      });
+    });
+  });
+
+  describe('copyChecklist', () => {
+    it('should post with idChecklistSource', async () => {
+      const checklist = { id: 'cl2', name: 'Copied', checkItems: [] };
+      mockAxiosInstance.post.mockResolvedValue({ data: checklist });
+
+      const client = createClient();
+      const result = await client.copyChecklist({
+        sourceChecklistId: 'cl1',
+        cardId: 'c2',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/checklists', {
+        idCard: 'c2',
+        idChecklistSource: 'cl1',
+        name: undefined,
+        pos: undefined,
+      });
+      expect(result).toEqual(checklist);
+    });
+
+    it('should allow overriding name', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'cl2' } });
+
+      const client = createClient();
+      await client.copyChecklist({
+        sourceChecklistId: 'cl1',
+        cardId: 'c2',
+        name: 'Renamed Checklist',
+        pos: 'top',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/checklists', {
+        idCard: 'c2',
+        idChecklistSource: 'cl1',
+        name: 'Renamed Checklist',
+        pos: 'top',
+      });
+    });
+  });
+
+  describe('batchAddCards', () => {
+    it('should create multiple cards sequentially', async () => {
+      mockAxiosInstance.post
+        .mockResolvedValueOnce({ data: { id: 'c1', name: 'Card 1' } })
+        .mockResolvedValueOnce({ data: { id: 'c2', name: 'Card 2' } })
+        .mockResolvedValueOnce({ data: { id: 'c3', name: 'Card 3' } });
+
+      const client = createClient();
+      const results = await client.batchAddCards('l1', [
+        { name: 'Card 1' },
+        { name: 'Card 2', description: 'Desc' },
+        { name: 'Card 3', labels: ['lbl1'] },
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(3);
+      expect(results[0].name).toBe('Card 1');
+      expect(results[2].name).toBe('Card 3');
+    });
+
+    it('should handle empty array', async () => {
+      const client = createClient();
+      const results = await client.batchAddCards('l1', []);
+      expect(results).toEqual([]);
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('should propagate errors from individual card creation', async () => {
+      mockAxiosInstance.post
+        .mockResolvedValueOnce({ data: { id: 'c1' } })
+        .mockRejectedValueOnce(new Error('API Error'));
+
+      const client = createClient();
+      await expect(
+        client.batchAddCards('l1', [{ name: 'Card 1' }, { name: 'Card 2' }])
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getCard', () => {
+    it('should fetch card with all fields', async () => {
+      const card = { id: 'c1', name: 'Card', checklists: [], labels: [] };
+      mockAxiosInstance.get.mockResolvedValue({ data: card });
+
+      const client = createClient();
+      await client.getCard('c1');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/cards/c1', {
+        params: expect.objectContaining({
+          attachments: true,
+          checklists: 'all',
+          members: true,
+          labels: true,
+        }),
+      });
+    });
+  });
+
+  describe('getCardHistory', () => {
+    it('should fetch card actions with optional params', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient();
+      await client.getCardHistory('c1', 'commentCard', 10);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/cards/c1/actions', {
+        params: { filter: 'commentCard', limit: 10 },
+      });
+    });
+
+    it('should fetch without optional params', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      const client = createClient();
+      await client.getCardHistory('c1');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/cards/c1/actions', {
+        params: {},
+      });
+    });
+  });
+
+  describe('Config persistence', () => {
+    it('activeBoardId should return configured board', () => {
+      const client = createClient({ boardId: 'b1' });
+      expect(client.activeBoardId).toBe('b1');
+    });
+
+    it('activeBoardId should return undefined when not set', () => {
+      const client = createClient();
+      expect(client.activeBoardId).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateString,
+  validateOptionalString,
+  validateNumber,
+  validateOptionalNumber,
+  validateStringArray,
+  validateOptionalStringArray,
+  validateBoolean,
+  validateOptionalBoolean,
+  validateOptionalDateString,
+  validateGetCardsListRequest,
+  validateGetListsRequest,
+  validateGetRecentActivityRequest,
+  validateAddCardRequest,
+  validateUpdateCardRequest,
+  validateArchiveCardRequest,
+  validateAddListRequest,
+  validateArchiveListRequest,
+  validateMoveCardRequest,
+  validateAttachImageRequest,
+  validateSetActiveBoardRequest,
+  validateSetActiveWorkspaceRequest,
+  validateListBoardsInWorkspaceRequest,
+  validateGetCardRequest,
+} from '../../src/validators.js';
+
+describe('Primitive Validators', () => {
+  describe('validateString', () => {
+    it('should return string when given a string', () => {
+      expect(validateString('hello', 'field')).toBe('hello');
+    });
+
+    it('should return empty string', () => {
+      expect(validateString('', 'field')).toBe('');
+    });
+
+    it('should throw on number', () => {
+      expect(() => validateString(123, 'myField')).toThrow('myField must be a string');
+    });
+
+    it('should throw on null', () => {
+      expect(() => validateString(null, 'field')).toThrow();
+    });
+
+    it('should throw on undefined', () => {
+      expect(() => validateString(undefined, 'field')).toThrow();
+    });
+
+    it('should throw on boolean', () => {
+      expect(() => validateString(true, 'field')).toThrow();
+    });
+  });
+
+  describe('validateOptionalString', () => {
+    it('should return undefined when given undefined', () => {
+      expect(validateOptionalString(undefined)).toBeUndefined();
+    });
+
+    it('should return string when given a string', () => {
+      expect(validateOptionalString('test')).toBe('test');
+    });
+
+    it('should throw on non-string, non-undefined', () => {
+      expect(() => validateOptionalString(42)).toThrow();
+    });
+  });
+
+  describe('validateNumber', () => {
+    it('should return number when given a number', () => {
+      expect(validateNumber(42, 'field')).toBe(42);
+    });
+
+    it('should accept 0', () => {
+      expect(validateNumber(0, 'field')).toBe(0);
+    });
+
+    it('should accept negative numbers', () => {
+      expect(validateNumber(-5, 'field')).toBe(-5);
+    });
+
+    it('should throw on string', () => {
+      expect(() => validateNumber('42', 'myField')).toThrow('myField must be a number');
+    });
+  });
+
+  describe('validateOptionalNumber', () => {
+    it('should return undefined when given undefined', () => {
+      expect(validateOptionalNumber(undefined)).toBeUndefined();
+    });
+
+    it('should return number when given a number', () => {
+      expect(validateOptionalNumber(10)).toBe(10);
+    });
+  });
+
+  describe('validateStringArray', () => {
+    it('should return array of strings', () => {
+      expect(validateStringArray(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('should accept empty array', () => {
+      expect(validateStringArray([])).toEqual([]);
+    });
+
+    it('should throw on non-array', () => {
+      expect(() => validateStringArray('not array')).toThrow();
+    });
+
+    it('should throw on array with non-strings', () => {
+      expect(() => validateStringArray(['a', 1])).toThrow();
+    });
+
+    it('should throw on mixed array', () => {
+      expect(() => validateStringArray([1, 2, 3])).toThrow();
+    });
+  });
+
+  describe('validateOptionalStringArray', () => {
+    it('should return undefined when given undefined', () => {
+      expect(validateOptionalStringArray(undefined)).toBeUndefined();
+    });
+
+    it('should return array when given valid array', () => {
+      expect(validateOptionalStringArray(['a'])).toEqual(['a']);
+    });
+  });
+
+  describe('validateBoolean', () => {
+    it('should return true', () => {
+      expect(validateBoolean(true, 'field')).toBe(true);
+    });
+
+    it('should return false', () => {
+      expect(validateBoolean(false, 'field')).toBe(false);
+    });
+
+    it('should throw on string', () => {
+      expect(() => validateBoolean('true', 'field')).toThrow();
+    });
+
+    it('should throw on number', () => {
+      expect(() => validateBoolean(1, 'field')).toThrow();
+    });
+  });
+
+  describe('validateOptionalBoolean', () => {
+    it('should return undefined when given undefined', () => {
+      expect(validateOptionalBoolean(undefined)).toBeUndefined();
+    });
+
+    it('should return boolean when given boolean', () => {
+      expect(validateOptionalBoolean(true)).toBe(true);
+    });
+  });
+
+  describe('validateOptionalDateString', () => {
+    it('should return undefined when given undefined', () => {
+      expect(validateOptionalDateString(undefined)).toBeUndefined();
+    });
+
+    it('should accept valid YYYY-MM-DD format', () => {
+      expect(validateOptionalDateString('2024-01-15')).toBe('2024-01-15');
+    });
+
+    it('should reject invalid date format (MM/DD/YYYY)', () => {
+      expect(() => validateOptionalDateString('01/15/2024')).toThrow('YYYY-MM-DD');
+    });
+
+    it('should reject ISO 8601 datetime', () => {
+      expect(() => validateOptionalDateString('2024-01-15T10:30:00Z')).toThrow('YYYY-MM-DD');
+    });
+
+    it('should reject partial date', () => {
+      expect(() => validateOptionalDateString('2024-01')).toThrow('YYYY-MM-DD');
+    });
+
+    it('should reject non-string', () => {
+      expect(() => validateOptionalDateString(20240115)).toThrow();
+    });
+  });
+});
+
+describe('Request Validators', () => {
+  describe('validateGetCardsListRequest', () => {
+    it('should require listId', () => {
+      expect(() => validateGetCardsListRequest({})).toThrow('listId is required');
+    });
+
+    it('should accept listId only', () => {
+      const result = validateGetCardsListRequest({ listId: 'list123' });
+      expect(result).toEqual({ boardId: undefined, listId: 'list123' });
+    });
+
+    it('should accept both boardId and listId', () => {
+      const result = validateGetCardsListRequest({ boardId: 'board1', listId: 'list1' });
+      expect(result).toEqual({ boardId: 'board1', listId: 'list1' });
+    });
+  });
+
+  describe('validateGetListsRequest', () => {
+    it('should accept empty args', () => {
+      expect(validateGetListsRequest({})).toEqual({ boardId: undefined });
+    });
+
+    it('should accept boardId', () => {
+      expect(validateGetListsRequest({ boardId: 'b1' })).toEqual({ boardId: 'b1' });
+    });
+  });
+
+  describe('validateGetRecentActivityRequest', () => {
+    it('should accept empty args', () => {
+      const result = validateGetRecentActivityRequest({});
+      expect(result).toEqual({ boardId: undefined, limit: undefined });
+    });
+
+    it('should accept boardId and limit', () => {
+      const result = validateGetRecentActivityRequest({ boardId: 'b1', limit: 5 });
+      expect(result).toEqual({ boardId: 'b1', limit: 5 });
+    });
+  });
+
+  describe('validateAddCardRequest', () => {
+    it('should require listId and name', () => {
+      expect(() => validateAddCardRequest({})).toThrow('listId and name are required');
+      expect(() => validateAddCardRequest({ listId: 'l1' })).toThrow('listId and name are required');
+      expect(() => validateAddCardRequest({ name: 'card' })).toThrow('listId and name are required');
+    });
+
+    it('should accept minimal valid request', () => {
+      const result = validateAddCardRequest({ listId: 'l1', name: 'Card 1' });
+      expect(result.listId).toBe('l1');
+      expect(result.name).toBe('Card 1');
+    });
+
+    it('should accept all optional fields', () => {
+      const result = validateAddCardRequest({
+        listId: 'l1',
+        name: 'Card',
+        boardId: 'b1',
+        description: 'desc',
+        dueDate: '2024-01-01T00:00:00Z',
+        start: '2024-01-01',
+        labels: ['label1'],
+      });
+      expect(result.boardId).toBe('b1');
+      expect(result.description).toBe('desc');
+      expect(result.start).toBe('2024-01-01');
+      expect(result.labels).toEqual(['label1']);
+    });
+
+    it('should reject invalid start date format', () => {
+      expect(() =>
+        validateAddCardRequest({ listId: 'l1', name: 'Card', start: 'not-a-date' })
+      ).toThrow('YYYY-MM-DD');
+    });
+  });
+
+  describe('validateUpdateCardRequest', () => {
+    it('should require cardId', () => {
+      expect(() => validateUpdateCardRequest({})).toThrow('cardId is required');
+    });
+
+    it('should accept cardId only', () => {
+      const result = validateUpdateCardRequest({ cardId: 'c1' });
+      expect(result.cardId).toBe('c1');
+    });
+
+    it('should accept dueComplete boolean', () => {
+      const result = validateUpdateCardRequest({ cardId: 'c1', dueComplete: true });
+      expect(result.dueComplete).toBe(true);
+    });
+  });
+
+  describe('validateArchiveCardRequest', () => {
+    it('should require cardId', () => {
+      expect(() => validateArchiveCardRequest({})).toThrow('cardId is required');
+    });
+
+    it('should accept valid request', () => {
+      expect(validateArchiveCardRequest({ cardId: 'c1' })).toEqual({
+        boardId: undefined,
+        cardId: 'c1',
+      });
+    });
+  });
+
+  describe('validateAddListRequest', () => {
+    it('should require name', () => {
+      expect(() => validateAddListRequest({})).toThrow('name is required');
+    });
+
+    it('should accept name', () => {
+      expect(validateAddListRequest({ name: 'My List' })).toEqual({
+        boardId: undefined,
+        name: 'My List',
+      });
+    });
+  });
+
+  describe('validateArchiveListRequest', () => {
+    it('should require listId', () => {
+      expect(() => validateArchiveListRequest({})).toThrow('listId is required');
+    });
+  });
+
+  describe('validateMoveCardRequest', () => {
+    it('should require cardId and listId', () => {
+      expect(() => validateMoveCardRequest({})).toThrow('cardId and listId are required');
+      expect(() => validateMoveCardRequest({ cardId: 'c1' })).toThrow();
+      expect(() => validateMoveCardRequest({ listId: 'l1' })).toThrow();
+    });
+
+    it('should accept valid request', () => {
+      const result = validateMoveCardRequest({ cardId: 'c1', listId: 'l1' });
+      expect(result).toEqual({ boardId: undefined, cardId: 'c1', listId: 'l1' });
+    });
+  });
+
+  describe('validateAttachImageRequest', () => {
+    it('should require cardId and imageUrl', () => {
+      expect(() => validateAttachImageRequest({})).toThrow('cardId and imageUrl are required');
+    });
+
+    it('should reject invalid URL', () => {
+      expect(() =>
+        validateAttachImageRequest({ cardId: 'c1', imageUrl: 'not-a-url' })
+      ).toThrow('valid URL');
+    });
+
+    it('should accept valid URL', () => {
+      const result = validateAttachImageRequest({
+        cardId: 'c1',
+        imageUrl: 'https://example.com/image.png',
+      });
+      expect(result.imageUrl).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('validateSetActiveBoardRequest', () => {
+    it('should require boardId', () => {
+      expect(() => validateSetActiveBoardRequest({})).toThrow('boardId is required');
+    });
+
+    it('should accept boardId', () => {
+      expect(validateSetActiveBoardRequest({ boardId: 'b1' })).toEqual({ boardId: 'b1' });
+    });
+  });
+
+  describe('validateSetActiveWorkspaceRequest', () => {
+    it('should require workspaceId', () => {
+      expect(() => validateSetActiveWorkspaceRequest({})).toThrow('workspaceId is required');
+    });
+  });
+
+  describe('validateListBoardsInWorkspaceRequest', () => {
+    it('should require workspaceId', () => {
+      expect(() => validateListBoardsInWorkspaceRequest({})).toThrow('workspaceId is required');
+    });
+  });
+
+  describe('validateGetCardRequest', () => {
+    it('should require cardId', () => {
+      expect(() => validateGetCardRequest({})).toThrow('cardId is required');
+    });
+
+    it('should accept cardId with optional includeMarkdown', () => {
+      const result = validateGetCardRequest({ cardId: 'c1', includeMarkdown: true });
+      expect(result).toEqual({ cardId: 'c1', includeMarkdown: true });
+    });
+
+    it('should accept cardId without includeMarkdown', () => {
+      const result = validateGetCardRequest({ cardId: 'c1' });
+      expect(result).toEqual({ cardId: 'c1', includeMarkdown: undefined });
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { config } from 'dotenv';
+
+const dotenvResult = config();
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['tests/**/*.test.ts'],
     testTimeout: 30000,
+    env: dotenvResult.parsed,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
- **121 unit tests** covering `rate-limiter`, `validators`, and `trello-client` (with mocked axios)
- **26 smoke tests** against live Trello API (auto-skipped when `TRELLO_API_KEY`/`TRELLO_TOKEN` env vars are absent)
- Adds `vitest` as the test framework with scripts: `npm run test`, `npm run test:unit`, `npm run test:smoke`
- Tests cover all existing tools plus the new `copy_card`, `copy_checklist`, and `add_cards_to_list` features

## Bug found during testing
Some tools return **plain text** instead of JSON, inconsistent with the rest of the codebase:
- `set_active_board` returns `"Successfully set active board to..."`
- `delete_comment` / `delete_label` return `"success"` / `"Label deleted successfully"`
- All other tools return `JSON.stringify(result)`

This is a minor inconsistency (not a breaking issue), noted for future cleanup.

## Test plan
- [x] All 121 unit tests pass
- [x] All 26 smoke tests pass against live Trello board
- [x] Smoke tests auto-skip when no credentials are set
- [ ] Verify CI integration (add env vars as secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)