### PR TITLE
Truncate card descriptions in get_cards_by_list_id

### DIFF
--- a/src/card-list-preview.ts
+++ b/src/card-list-preview.ts
@@ -1,0 +1,56 @@
+import type { TrelloCard } from './types.js';
+
+const DEFAULT_DESC_MAX_LENGTH = 200;
+const DEFAULT_OMIT_DESC_THRESHOLD_BYTES = 50000;
+
+type TextContent = { type: 'text'; text: string };
+
+export function formatCardListResponse(
+  cards: TrelloCard[],
+  options: {
+    descMaxLength?: number;
+    omitDescThresholdBytes?: number;
+  } = {}
+): { content: TextContent[] } {
+  const descMaxLength = options.descMaxLength ?? DEFAULT_DESC_MAX_LENGTH;
+  const omitDescThresholdBytes =
+    options.omitDescThresholdBytes ?? DEFAULT_OMIT_DESC_THRESHOLD_BYTES;
+
+  let anyTruncated = false;
+  const previewCards = cards.map((card) => {
+    if (!card.desc || card.desc.length <= descMaxLength) {
+      return card;
+    }
+
+    anyTruncated = true;
+    const suffix = descMaxLength >= 3 ? '...' : '';
+    const sliceLength = Math.max(0, descMaxLength - suffix.length);
+    return { ...card, desc: `${card.desc.slice(0, sliceLength)}${suffix}` };
+  });
+
+  let resultCards: Array<TrelloCard | Omit<TrelloCard, 'desc'>> = previewCards;
+  let descriptionsOmitted = false;
+  let result = JSON.stringify(resultCards, null, 2);
+
+  if (Buffer.byteLength(result, 'utf8') > omitDescThresholdBytes) {
+    resultCards = cards.map(({ desc, ...rest }) => rest);
+    result = JSON.stringify(resultCards, null, 2);
+    descriptionsOmitted = true;
+  }
+
+  const content: TextContent[] = [{ type: 'text', text: result }];
+
+  if (descriptionsOmitted) {
+    content.push({
+      type: 'text',
+      text: 'Descriptions omitted due to response size. Use get_card with a specific cardId for full details, or request fields without desc when listing cards.',
+    });
+  } else if (anyTruncated) {
+    content.push({
+      type: 'text',
+      text: 'Some descriptions were truncated. Use get_card with a specific cardId for full details, or increase descMaxLength for a longer preview.',
+    });
+  }
+
+  return { content };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { TrelloClient } from './trello-client.js';
 import { TrelloHealthEndpoints, HealthEndpointSchemas } from './health/health-endpoints.js';
+import { formatCardListResponse } from './card-list-preview.js';
 
 class TrelloServer {
   private server: McpServer;
@@ -68,7 +69,8 @@ class TrelloServer {
       'get_cards_by_list_id',
       {
         title: 'Get Cards by List ID',
-        description: 'Fetch cards from a specific Trello list on a specific board',
+        description:
+          'Fetch cards from a specific Trello list on a specific board. Descriptions are previewed by default to keep responses compact; set fields without "desc" to omit descriptions, or increase descMaxLength/omitDescThresholdBytes and use get_card for full details.',
         inputSchema: {
           boardId: z
             .string()
@@ -85,14 +87,28 @@ class TrelloServer {
             .min(1, 'nameFilter must not be empty')
             .optional()
             .describe('Optional substring to filter cards by name (case-insensitive)'),
+          descMaxLength: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe(
+              'Maximum description preview length per card. Defaults to 200. Increase for fuller descriptions.'
+            ),
+          omitDescThresholdBytes: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              'Approximate response size threshold before descriptions are omitted. Defaults to 50000 bytes.'
+            ),
         },
       },
-      async ({ listId, fields, nameFilter }) => {
+      async ({ listId, fields, nameFilter, descMaxLength, omitDescThresholdBytes }) => {
         try {
           const cards = await this.trelloClient.getCardsByList(listId, fields, nameFilter);
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify(cards, null, 2) }],
-          };
+          return formatCardListResponse(cards, { descMaxLength, omitDescThresholdBytes });
         } catch (error) {
           return this.handleError(error);
         }

--- a/tests/unit/card-list-preview.test.ts
+++ b/tests/unit/card-list-preview.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { formatCardListResponse } from '../../src/card-list-preview.js';
+import type { TrelloCard } from '../../src/types.js';
+
+function card(overrides: Partial<TrelloCard> = {}): TrelloCard {
+  return {
+    id: 'card-1',
+    name: 'Card 1',
+    desc: 'short description',
+    due: null,
+    idList: 'list-1',
+    idLabels: [],
+    closed: false,
+    url: 'https://trello.example/card-1',
+    dateLastActivity: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('formatCardListResponse', () => {
+  it('truncates long descriptions and returns a separate notice', () => {
+    const response = formatCardListResponse([card({ desc: 'abcdef' })], {
+      descMaxLength: 5,
+    });
+
+    const cards = JSON.parse(response.content[0].text);
+    expect(cards[0].desc).toBe('ab...');
+    expect(response.content[1].text).toContain('Some descriptions were truncated');
+  });
+
+  it('allows callers to opt into longer descriptions', () => {
+    const response = formatCardListResponse([card({ desc: 'abcdef' })], {
+      descMaxLength: 20,
+    });
+
+    const cards = JSON.parse(response.content[0].text);
+    expect(cards[0].desc).toBe('abcdef');
+    expect(response.content).toHaveLength(1);
+  });
+
+  it('omits descriptions when the serialized response exceeds the threshold', () => {
+    const response = formatCardListResponse([card({ desc: 'abcdef' })], {
+      descMaxLength: 20,
+      omitDescThresholdBytes: 1,
+    });
+
+    const cards = JSON.parse(response.content[0].text);
+    expect(cards[0]).not.toHaveProperty('desc');
+    expect(response.content[1].text).toContain('Descriptions omitted');
+  });
+});


### PR DESCRIPTION
## Summary
- `get_cards_by_list_id` can return very large responses when cards have long descriptions, which wastes context window for LLM consumers
- Card descriptions are now truncated to 200 characters in list responses
- If total response still exceeds 50KB, descriptions are omitted entirely
- Both cases append a notice directing users to `get_card` for full details

## Behavior
| Scenario | Before | After |
|----------|--------|-------|
| Cards with short descriptions | Full response | No change |
| Cards with long descriptions | Full descriptions (unbounded) | Truncated to 200 chars + notice |
| Many cards with content > 50KB total | Huge response | Descriptions dropped + notice |

## Test plan
- [x] Build passes
- [x] Verified against live board with cards
- [ ] Test with board containing cards with very long descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)