### PR TITLE
v1.7.2 - Scope persisted config by working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-02-17
+
+### Fixed
+- **Config Isolation**: Persisted board/workspace config is now scoped by working directory, preventing cross-project data leakage when multiple MCP server instances share `~/.trello-mcp/`
+- One-time migration automatically moves the legacy `config.json` to a directory-scoped file
+
 ## [1.7.0] - 2025-12-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@delorenj/mcp-server-trello",
   "mcpName": "io.github.delorenj/mcp-server-trello",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "An MCP server for Trello boards, powered by Bun for maximum performance.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- Persisted board/workspace config is now scoped by working directory hash, preventing cross-project data leakage when multiple MCP server instances share `~/.trello-mcp/`
- One-time migration automatically copies the legacy `config.json` to a directory-scoped file and removes the legacy file
- Saved config includes `directory` field for debuggability

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Setting an active board creates `~/.trello-mcp/config-<hash>.json` (not `config.json`)
- [ ] Two different working directories produce different config files
- [ ] If a legacy `config.json` exists, it migrates on first `loadConfig()` and is deleted