### PR TITLE
Add native HTTPS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ TRELLO_BOARD_ID=your-board-id
 
 # Optional: Initial workspace ID (can be changed later using set_active_workspace)
 TRELLO_WORKSPACE_ID=your-workspace-id
+
+# Optional: HTTPS proxy URL (for corporate proxies or restricted networks)
+https_proxy=http://your-proxy:8080
 ```
+
+> **Proxy Support:** If you're behind a corporate proxy or in an environment that routes traffic through a proxy, set the `https_proxy` or `HTTPS_PROXY` environment variable. The server will automatically route all Trello API requests through the specified proxy.
 
 You can get these values from:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@delorenj/mcp-server-trello",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@delorenj/mcp-server-trello",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
         "axios": "^1.13.2",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^7.0.6",
         "mcp-evals": "^1.0.18",
         "zod": "^3.25.76"
       },
@@ -1236,6 +1237,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -2758,6 +2768,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
     "axios": "^1.13.2",
+    "https-proxy-agent": "^7.0.6",
     "form-data": "^4.0.5",
     "mcp-evals": "^1.0.18",
     "zod": "^3.25.76"

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import FormData from 'form-data';
 import {
   TrelloConfig,
@@ -59,13 +60,23 @@ export class TrelloClient {
     if (this.defaultBoardId && !this.activeConfig.boardId) {
       this.activeConfig.boardId = this.defaultBoardId;
     }
-    this.axiosInstance = axios.create({
+    const axiosConfig: Record<string, unknown> = {
       baseURL: 'https://api.trello.com/1',
       params: {
         key: config.apiKey,
         token: config.token,
       },
-    });
+    };
+
+    const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
+    if (proxyUrl) {
+      const agent = new HttpsProxyAgent(proxyUrl);
+      axiosConfig.httpAgent = agent;
+      axiosConfig.httpsAgent = agent;
+      axiosConfig.proxy = false;
+    }
+
+    this.axiosInstance = axios.create(axiosConfig);
 
     this.rateLimiter = createTrelloRateLimiters();
 

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, CreateAxiosDefaults } from 'axios';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import FormData from 'form-data';
 import {
@@ -60,7 +60,7 @@ export class TrelloClient {
     if (this.defaultBoardId && !this.activeConfig.boardId) {
       this.activeConfig.boardId = this.defaultBoardId;
     }
-    const axiosConfig: Record<string, unknown> = {
+    const axiosConfig: CreateAxiosDefaults = {
       baseURL: 'https://api.trello.com/1',
       params: {
         key: config.apiKey,


### PR DESCRIPTION
## Summary

- Adds `https-proxy-agent` dependency to automatically route Trello API requests through an HTTPS proxy when the `https_proxy` or `HTTPS_PROXY` environment variable is set
- Configures the proxy agent on the axios instance in the `TrelloClient` constructor, with `proxy: false` to prevent axios's built-in proxy handling from conflicting
- Documents proxy support in the README under the Environment Variables section

## Motivation

Axios does not respect `https_proxy`/`HTTPS_PROXY` environment variables out of the box. This causes 403 errors when running behind a corporate proxy or in environments like Claude Code web that route traffic through a proxy. Previously, users had to manually patch the built `index.js` to inject proxy support — a fragile workaround that breaks on version updates.

## Test plan

- [x] `npm install` resolves the new dependency
- [x] `bun build` succeeds and the proxy agent code is present in the bundle
- [ ] Verified with `HTTPS_PROXY` set — requests route through the proxy
- [ ] Verified without proxy env var — no behavior change (existing tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)