### PR TITLE
feat: Add custom field management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,51 @@ s; name: 'get_active_board_info',
 }
 ```
 
+### Custom Field Management Tools
+
+> **Note:** Custom fields require Trello Standard plan or higher.
+
+#### get\_board\_custom\_fields
+
+Get all custom field definitions on a board. For dropdown/list fields, also returns the available options with their IDs.
+
+```typescript
+{
+  name: 'get_board_custom_fields',
+  arguments: {
+    boardId?: string  // Optional: ID of the board (uses default if not provided)
+  }
+}
+```
+
+**Returns:** Array of custom field definitions including:
+- Field ID, name, type (`text`, `number`, `checkbox`, `date`, `list`)
+- For `list` type fields: available options with IDs (use these IDs when setting values)
+
+#### update\_card\_custom\_field
+
+Set or clear a custom field value on a card.
+
+```typescript
+{
+  name: 'update_card_custom_field',
+  arguments: {
+    cardId: string,       // ID of the card to update
+    customFieldId: string,// ID of the custom field definition
+    type: string,         // Field type: 'text' | 'number' | 'checkbox' | 'date' | 'list' | 'clear'
+    value?: string        // The value to set (not needed when type is 'clear')
+  }
+}
+```
+
+**Value format by type:**
+- `text`: any string
+- `number`: numeric string (e.g. `"42.5"`)
+- `checkbox`: `"true"` or `"false"`
+- `date`: ISO 8601 string (e.g. `"2025-12-31T00:00:00.000Z"`)
+- `list`: option ID from `get_board_custom_fields`
+- `clear`: omit value to remove the field value
+
 ## Integration Examples
 
 ### 🎨 Pairing with Ideogram MCP Server

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -76,6 +76,30 @@ const mark_card_completeEval: EvalFunction = {
   },
 };
 
+const get_board_custom_fieldsEval: EvalFunction = {
+  name: 'get_board_custom_fields Tool Evaluation',
+  description: 'Evaluates the get_board_custom_fields tool by retrieving custom field definitions',
+  run: async () => {
+    const result = await grade(
+      openai('gpt-4'),
+      'Please retrieve all custom field definitions from the board with ID abc123, including any dropdown options.'
+    );
+    return JSON.parse(result);
+  },
+};
+
+const update_card_custom_fieldEval: EvalFunction = {
+  name: 'update_card_custom_field Tool Evaluation',
+  description: 'Evaluates the update_card_custom_field tool by setting a custom field value on a card',
+  run: async () => {
+    const result = await grade(
+      openai('gpt-4'),
+      "Please set the custom field with ID 'cf456' on card 'card789' to the text value 'High Priority'."
+    );
+    return JSON.parse(result);
+  },
+};
+
 const config: EvalConfig = {
   model: openai('gpt-4'),
   evals: [
@@ -85,6 +109,8 @@ const config: EvalConfig = {
     add_card_to_listEval,
     update_card_detailsEval,
     mark_card_completeEval,
+    get_board_custom_fieldsEval,
+    update_card_custom_fieldEval,
   ],
 };
 
@@ -97,4 +123,6 @@ export const evals = [
   add_card_to_listEval,
   update_card_detailsEval,
   mark_card_completeEval,
+  get_board_custom_fieldsEval,
+  update_card_custom_fieldEval,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1538,6 +1538,108 @@ class TrelloServer {
       }
     );
 
+    // Custom field management tools
+    this.server.registerTool(
+      'get_board_custom_fields',
+      {
+        title: 'Get Board Custom Fields',
+        description:
+          'Get all custom field definitions on a board. Returns field IDs, names, and types. ' +
+          'For dropdown/list fields, also returns available options with their IDs. ' +
+          'Requires Trello Standard plan or higher.',
+        inputSchema: {
+          boardId: z
+            .string()
+            .optional()
+            .describe('ID of the Trello board (uses default if not provided)'),
+        },
+      },
+      async ({ boardId }) => {
+        try {
+          const fields = await this.trelloClient.getBoardCustomFields(boardId);
+
+          const fieldsWithOptions = await Promise.all(
+            fields.map(async (field) => {
+              if (field.type !== 'list') {
+                return field;
+              }
+
+              try {
+                const options = await this.trelloClient.getCustomFieldOptions(field.id);
+                return { ...field, options };
+              } catch (error) {
+                return {
+                  ...field,
+                  optionsError: error instanceof Error ? error.message : 'Failed to fetch options',
+                };
+              }
+            })
+          );
+
+          return {
+            content: [
+              { type: 'text' as const, text: JSON.stringify(fieldsWithOptions, null, 2) },
+            ],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    this.server.registerTool(
+      'update_card_custom_field',
+      {
+        title: 'Update Card Custom Field',
+        description:
+          'Set or clear a custom field value on a card. Requires Trello Standard plan or higher. ' +
+          'Use get_board_custom_fields first to find field IDs and types. ' +
+          'Value format depends on type: text=any string, number=numeric string, ' +
+          'checkbox="true"/"false", date=ISO 8601 string, list=option ID from get_board_custom_fields. ' +
+          'To clear a field, set type to "clear" and omit value.',
+        inputSchema: {
+          cardId: z.string().describe('ID of the card to update'),
+          customFieldId: z.string().describe('ID of the custom field definition'),
+          type: z
+            .enum(['text', 'number', 'checkbox', 'date', 'list', 'clear'])
+            .describe('The custom field type. Use "clear" to remove the value from the field.'),
+          value: z
+            .string()
+            .optional()
+            .describe(
+              'The value to set. For text: any string. For number: numeric string (e.g. "42.5"). ' +
+                'For checkbox: "true" or "false". For date: ISO 8601 (e.g. "2025-12-31T00:00:00.000Z"). ' +
+                'For list: the option ID. Not needed when type is "clear".'
+            ),
+        },
+      },
+      async ({ cardId, customFieldId, type, value }) => {
+        try {
+          if (type !== 'clear' && !value) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Error: value is required when type is not "clear"',
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const result = await this.trelloClient.updateCardCustomField(cardId, customFieldId, {
+            type,
+            value,
+          });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
     // Card history tool
     this.server.registerTool(
       'get_card_history',

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1274,6 +1274,7 @@ export class TrelloClient {
       } else if (params.type === 'date') {
         body = { value: { date: params.value } };
       } else {
+        // Defensive: unreachable with current type union, guards against future additions
         throw new McpError(ErrorCode.InvalidParams, `Unknown custom field type: ${params.type}`);
       }
 

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -17,6 +17,9 @@ import {
   TrelloComment,
   TrelloMember,
   TrelloLabelDetails,
+  TrelloCustomFieldDefinition,
+  TrelloCustomFieldOption,
+  TrelloCustomFieldItem,
 } from './types.js';
 import { createTrelloRateLimiters } from './rate-limiter.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
@@ -40,7 +43,10 @@ type TrelloRequestReturn =
   | string
   | boolean
   | TrelloList
-  | TrelloWorkspace;
+  | TrelloWorkspace
+  | TrelloCustomFieldDefinition
+  | TrelloCustomFieldOption
+  | TrelloCustomFieldItem;
 
 export class TrelloClient {
   private axiosInstance: AxiosInstance;
@@ -1220,6 +1226,63 @@ export class TrelloClient {
       }
     }
     return { created, errors };
+  }
+
+  // Custom field management methods
+  async getBoardCustomFields(boardId?: string): Promise<TrelloCustomFieldDefinition[]> {
+    const effectiveBoardId = boardId || this.activeConfig.boardId || this.defaultBoardId;
+    if (!effectiveBoardId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'boardId is required when no default board is configured'
+      );
+    }
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.get(`/boards/${effectiveBoardId}/customFields`);
+      return response.data;
+    });
+  }
+
+  async getCustomFieldOptions(customFieldId: string): Promise<TrelloCustomFieldOption[]> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.get(`/customFields/${customFieldId}/options`);
+      return response.data;
+    });
+  }
+
+  async updateCardCustomField(
+    cardId: string,
+    customFieldId: string,
+    params: {
+      type: 'text' | 'number' | 'checkbox' | 'date' | 'list' | 'clear';
+      value?: string;
+    }
+  ): Promise<TrelloCustomFieldItem> {
+    return this.handleRequest(async () => {
+      let body: Record<string, unknown>;
+
+      if (params.type === 'clear') {
+        body = { value: '', idValue: '' };
+      } else if (params.type === 'list') {
+        body = { idValue: params.value };
+      } else if (params.type === 'text') {
+        body = { value: { text: params.value } };
+      } else if (params.type === 'number') {
+        body = { value: { number: params.value } };
+      } else if (params.type === 'checkbox') {
+        body = { value: { checked: params.value } };
+      } else if (params.type === 'date') {
+        body = { value: { date: params.value } };
+      } else {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown custom field type: ${params.type}`);
+      }
+
+      const response = await this.axiosInstance.put(
+        `/cards/${cardId}/customField/${customFieldId}/item`,
+        body
+      );
+      return response.data;
+    });
   }
 
   // Card history method

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,11 +156,40 @@ export interface TrelloComment {
   };
 }
 
-export interface TrelloCustomField {
+export interface TrelloCustomFieldDefinition {
   id: string;
+  idModel: string;
+  modelType: string;
+  fieldGroup: string;
   name: string;
-  type: string;
-  value?: unknown;
+  type: 'text' | 'number' | 'checkbox' | 'date' | 'list';
+  pos: number;
+  display: {
+    cardFront: boolean;
+  };
+  options?: TrelloCustomFieldOption[];
+}
+
+export interface TrelloCustomFieldOption {
+  id: string;
+  idCustomField: string;
+  value: { text: string };
+  color: string;
+  pos: number;
+}
+
+export interface TrelloCustomFieldItem {
+  id: string;
+  idCustomField: string;
+  idModel: string;
+  modelType: string;
+  idValue?: string;
+  value?: {
+    text?: string;
+    number?: string;
+    checked?: string;
+    date?: string;
+  } | null;
 }
 
 export interface TrelloBadges {
@@ -223,7 +252,7 @@ export interface EnhancedTrelloCard {
   members: TrelloMember[];
   idMembers: string[];
   comments: TrelloComment[];
-  customFieldItems?: TrelloCustomField[];
+  customFieldItems?: TrelloCustomFieldItem[];
   badges: TrelloBadges;
   cover: TrelloCover;
 

--- a/tests/unit/trello-client.test.ts
+++ b/tests/unit/trello-client.test.ts
@@ -473,6 +473,41 @@ describe('TrelloClient', () => {
     });
   });
 
+  describe('custom fields', () => {
+    it('should set list custom fields using idValue', async () => {
+      const item = { id: 'item1', idCustomField: 'field1', idValue: 'option1' };
+      mockAxiosInstance.put.mockResolvedValue({ data: item });
+
+      const client = createClient();
+      const result = await client.updateCardCustomField('card1', 'field1', {
+        type: 'list',
+        value: 'option1',
+      });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+        '/cards/card1/customField/field1/item',
+        { idValue: 'option1' }
+      );
+      expect(result).toEqual(item);
+    });
+
+    it('should clear custom fields with value and idValue empty strings', async () => {
+      const item = { id: 'item1', idCustomField: 'field1', value: null };
+      mockAxiosInstance.put.mockResolvedValue({ data: item });
+
+      const client = createClient();
+      const result = await client.updateCardCustomField('card1', 'field1', {
+        type: 'clear',
+      });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+        '/cards/card1/customField/field1/item',
+        { value: '', idValue: '' }
+      );
+      expect(result).toEqual(item);
+    });
+  });
+
   describe('copyCard', () => {
     it('should post with idCardSource and keepFromSource=all by default', async () => {
       const copiedCard = { id: 'c2', name: 'Copied Card' };


### PR DESCRIPTION
## Summary

- Adds `get_board_custom_fields` tool — fetches all custom field definitions on a board, with inline options for dropdown/list-type fields via a single call
- Adds `update_card_custom_field` tool — set or clear custom field values on cards, supporting all field types: text, number, checkbox, date, and list (dropdown)
- Adds properly typed interfaces: `TrelloCustomFieldDefinition`, `TrelloCustomFieldOption`, `TrelloCustomFieldItem`
- Handles clearing correctly for both value-based fields (`value: ''`) and list-based fields (`idValue: ''`)

### Usage workflow
1. Call `get_board_custom_fields` to discover field definitions, IDs, types, and dropdown options
2. Card custom field values are already available via `get_card` (the `customFieldItems` property)
3. Call `update_card_custom_field` to set or clear values

### Notes
- Follows existing codebase patterns for tool registration, error handling, and board ID resolution
- Requires Trello Standard plan or higher (Trello API requirement for custom fields)

## Test plan
- [x] Tested `get_board_custom_fields` on a board with multiple custom field types including dropdowns
- [x] Tested `update_card_custom_field` for each field type (text, number, checkbox, date, list)
- [x] Tested clearing custom fields with `type: "clear"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)