### PR TITLE
Add since/before params to get_recent_activity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,11 +123,19 @@ class TrelloServer {
             .optional()
             .default(10)
             .describe('Number of activities to fetch (default: 10)'),
+          since: z
+            .string()
+            .optional()
+            .describe('Only return actions after this date (ISO 8601) or action ID'),
+          before: z
+            .string()
+            .optional()
+            .describe('Only return actions before this date (ISO 8601) or action ID'),
         },
       },
-      async ({ boardId, limit }) => {
+      async ({ boardId, limit, since, before }) => {
         try {
-          const activity = await this.trelloClient.getRecentActivity(boardId, limit);
+          const activity = await this.trelloClient.getRecentActivity(boardId, limit, since, before);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(activity, null, 2) }],
           };

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -272,7 +272,7 @@ export class TrelloClient {
     });
   }
 
-  async getRecentActivity(boardId?: string, limit: number = 10): Promise<TrelloAction[]> {
+  async getRecentActivity(boardId?: string, limit: number = 10, since?: string, before?: string): Promise<TrelloAction[]> {
     const effectiveBoardId = boardId || this.activeConfig.boardId || this.defaultBoardId;
     if (!effectiveBoardId) {
       throw new McpError(
@@ -281,8 +281,11 @@ export class TrelloClient {
       );
     }
     return this.handleRequest(async () => {
+      const params: Record<string, string | number> = { limit };
+      if (since) params.since = since;
+      if (before) params.before = before;
       const response = await this.axiosInstance.get(`/boards/${effectiveBoardId}/actions`, {
-        params: { limit },
+        params,
       });
       return response.data;
     });


### PR DESCRIPTION
## Summary

- Adds optional `since` and `before` parameters to the `get_recent_activity` tool
- These pass through to the Trello API's `GET /boards/{id}/actions` endpoint, which natively supports date-range filtering via ISO 8601 timestamps or action IDs
- Enables callers to poll only for new activity since their last check, rather than re-fetching the same recent actions every time

## Changes

- **`src/index.ts`** — Added `since` and `before` to the tool's input schema (both optional strings)
- **`src/trello-client.ts`** — Extended `getRecentActivity()` to accept and forward `since`/`before` query params

## Test plan

- [x] Verified `get_recent_activity` with `since` parameter returns only actions after the specified timestamp
- [x] Verified omitting `since`/`before` preserves existing behavior (returns last N actions)
- [x] Verified `before` parameter filters actions before the specified date

🤖 Generated with [Claude Code](https://claude.com/claude-code)