### PR TITLE
Add nameFilter to get_cards_by_list_id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,15 @@ class TrelloServer {
             .string()
             .optional()
             .describe('Comma-separated list of fields to return (e.g., "name,idShort,labels,due,dueComplete"). Omit for all fields.'),
+          nameFilter: z
+            .string()
+            .optional()
+            .describe('Optional substring to filter cards by name (case-insensitive)'),
         },
       },
-      async ({ listId, fields }) => {
+      async ({ listId, fields, nameFilter }) => {
         try {
-          const cards = await this.trelloClient.getCardsByList(listId, fields);
+          const cards = await this.trelloClient.getCardsByList(listId, fields, nameFilter);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(cards, null, 2) }],
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ class TrelloServer {
             .describe('Comma-separated list of fields to return (e.g., "name,idShort,labels,due,dueComplete"). Omit for all fields.'),
           nameFilter: z
             .string()
+            .trim()
+            .min(1, 'nameFilter must not be empty')
             .optional()
             .describe('Optional substring to filter cards by name (case-insensitive)'),
         },

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -261,11 +261,20 @@ export class TrelloClient {
     });
   }
 
-  async getCardsByList(listId: string, fields?: string): Promise<TrelloCard[]> {
+  async getCardsByList(
+    listId: string,
+    fields?: string,
+    nameFilter?: string
+  ): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
       const params = fields ? { fields } : {};
       const response = await this.axiosInstance.get(`/lists/${listId}/cards`, { params });
-      return response.data;
+      let cards: TrelloCard[] = response.data;
+      if (nameFilter) {
+        const searchTerm = nameFilter.toLowerCase();
+        cards = cards.filter((card) => card.name.toLowerCase().includes(searchTerm));
+      }
+      return cards;
     });
   }
 

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -270,8 +270,9 @@ export class TrelloClient {
       const params = fields ? { fields } : {};
       const response = await this.axiosInstance.get(`/lists/${listId}/cards`, { params });
       let cards: TrelloCard[] = response.data;
-      if (nameFilter) {
-        const searchTerm = nameFilter.toLowerCase();
+      const trimmed = nameFilter?.trim();
+      if (trimmed) {
+        const searchTerm = trimmed.toLowerCase();
         cards = cards.filter((card) => card.name.toLowerCase().includes(searchTerm));
       }
       return cards;

--- a/tests/get-cards-name-filter.test.ts
+++ b/tests/get-cards-name-filter.test.ts
@@ -1,11 +1,52 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
 import { TrelloClient } from '../src/trello-client.js';
 
 const MOCK_CARDS = [
-  { id: '1', name: 'FEAT: Add Slippage to Position History', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
-  { id: '2', name: 'FEAT: Execute trade slippage config', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
-  { id: '3', name: 'BUG: Fix login page crash', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
-  { id: '4', name: 'Add Slippage to Position History', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
+  {
+    id: '1',
+    name: 'FEAT: Add Slippage to Position History',
+    desc: '',
+    due: null,
+    idList: 'list1',
+    idLabels: [],
+    closed: false,
+    url: '',
+    dateLastActivity: '',
+  },
+  {
+    id: '2',
+    name: 'FEAT: Execute trade slippage config',
+    desc: '',
+    due: null,
+    idList: 'list1',
+    idLabels: [],
+    closed: false,
+    url: '',
+    dateLastActivity: '',
+  },
+  {
+    id: '3',
+    name: 'BUG: Fix login page crash',
+    desc: '',
+    due: null,
+    idList: 'list1',
+    idLabels: [],
+    closed: false,
+    url: '',
+    dateLastActivity: '',
+  },
+  {
+    id: '4',
+    name: 'Add Slippage to Position History',
+    desc: '',
+    due: null,
+    idList: 'list1',
+    idLabels: [],
+    closed: false,
+    url: '',
+    dateLastActivity: '',
+  },
 ];
 
 // Create a client and mock the axios instance's get method
@@ -13,10 +54,35 @@ function createMockedClient() {
   const client = new TrelloClient({ apiKey: 'fake', token: 'fake', boardId: 'board1' });
   // Replace the internal axios instance's get with a mock
   (client as any).axiosInstance = {
-    get: mock(() => Promise.resolve({ data: MOCK_CARDS })),
+    get: vi.fn(() => Promise.resolve({ data: MOCK_CARDS })),
   };
   return client;
 }
+
+// Mirror the schema from index.ts for validation tests
+const nameFilterSchema = z.string().trim().min(1, 'nameFilter must not be empty').optional();
+
+describe('nameFilter schema validation', () => {
+  it('accepts undefined', () => {
+    expect(nameFilterSchema.parse(undefined)).toBeUndefined();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => nameFilterSchema.parse('')).toThrow();
+  });
+
+  it('rejects whitespace-only string', () => {
+    expect(() => nameFilterSchema.parse('   ')).toThrow();
+  });
+
+  it('accepts valid string', () => {
+    expect(nameFilterSchema.parse('FEAT')).toBe('FEAT');
+  });
+
+  it('trims whitespace from valid string', () => {
+    expect(nameFilterSchema.parse('  FEAT  ')).toBe('FEAT');
+  });
+});
 
 describe('getCardsByList nameFilter', () => {
   let client: TrelloClient;
@@ -26,46 +92,53 @@ describe('getCardsByList nameFilter', () => {
   });
 
   it('returns all cards when no nameFilter is provided', async () => {
-    const cards = await client.getCardsByList('board1', 'list1');
+    const cards = await client.getCardsByList('list1');
     expect(cards).toHaveLength(4);
   });
 
   it('returns all cards when nameFilter is undefined', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', undefined);
-    expect(cards).toHaveLength(4);
-  });
-
-  it('returns all cards when nameFilter is empty string', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', '');
+    const cards = await client.getCardsByList('list1', undefined, undefined);
     expect(cards).toHaveLength(4);
   });
 
   it('filters by exact name match', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', 'Add Slippage to Position History');
+    const cards = await client.getCardsByList(
+      'list1',
+      undefined,
+      'Add Slippage to Position History'
+    );
     expect(cards).toHaveLength(2);
     expect(cards.map((c) => c.id)).toEqual(['1', '4']);
   });
 
   it('filters by substring match', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', 'FEAT');
+    const cards = await client.getCardsByList('list1', undefined, 'FEAT');
     expect(cards).toHaveLength(2);
     expect(cards.map((c) => c.id)).toEqual(['1', '2']);
   });
 
   it('filters case-insensitively', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', 'add slippage');
+    const cards = await client.getCardsByList('list1', undefined, 'add slippage');
     expect(cards).toHaveLength(2);
     expect(cards.map((c) => c.id)).toEqual(['1', '4']);
   });
 
   it('returns empty array when no cards match', async () => {
-    const cards = await client.getCardsByList('board1', 'list1', 'nonexistent card name');
+    const cards = await client.getCardsByList('list1', undefined, 'nonexistent card name');
     expect(cards).toHaveLength(0);
   });
 
   it('does not match non-contiguous substrings', async () => {
     // "Add History" is not a contiguous substring of any card name
-    const cards = await client.getCardsByList('board1', 'list1', 'Add History');
+    const cards = await client.getCardsByList('list1', undefined, 'Add History');
     expect(cards).toHaveLength(0);
+  });
+
+  it('passes requested fields while filtering by name', async () => {
+    const cards = await client.getCardsByList('list1', 'name,idList', 'FEAT');
+    expect(cards).toHaveLength(2);
+    expect((client as any).axiosInstance.get).toHaveBeenCalledWith('/lists/list1/cards', {
+      params: { fields: 'name,idList' },
+    });
   });
 });

--- a/tests/get-cards-name-filter.test.ts
+++ b/tests/get-cards-name-filter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { TrelloClient } from '../src/trello-client.js';
+
+const MOCK_CARDS = [
+  { id: '1', name: 'FEAT: Add Slippage to Position History', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
+  { id: '2', name: 'FEAT: Execute trade slippage config', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
+  { id: '3', name: 'BUG: Fix login page crash', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
+  { id: '4', name: 'Add Slippage to Position History', desc: '', due: null, idList: 'list1', idLabels: [], closed: false, url: '', dateLastActivity: '' },
+];
+
+// Create a client and mock the axios instance's get method
+function createMockedClient() {
+  const client = new TrelloClient({ apiKey: 'fake', token: 'fake', boardId: 'board1' });
+  // Replace the internal axios instance's get with a mock
+  (client as any).axiosInstance = {
+    get: mock(() => Promise.resolve({ data: MOCK_CARDS })),
+  };
+  return client;
+}
+
+describe('getCardsByList nameFilter', () => {
+  let client: TrelloClient;
+
+  beforeEach(() => {
+    client = createMockedClient();
+  });
+
+  it('returns all cards when no nameFilter is provided', async () => {
+    const cards = await client.getCardsByList('board1', 'list1');
+    expect(cards).toHaveLength(4);
+  });
+
+  it('returns all cards when nameFilter is undefined', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', undefined);
+    expect(cards).toHaveLength(4);
+  });
+
+  it('returns all cards when nameFilter is empty string', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', '');
+    expect(cards).toHaveLength(4);
+  });
+
+  it('filters by exact name match', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', 'Add Slippage to Position History');
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.id)).toEqual(['1', '4']);
+  });
+
+  it('filters by substring match', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', 'FEAT');
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.id)).toEqual(['1', '2']);
+  });
+
+  it('filters case-insensitively', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', 'add slippage');
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.id)).toEqual(['1', '4']);
+  });
+
+  it('returns empty array when no cards match', async () => {
+    const cards = await client.getCardsByList('board1', 'list1', 'nonexistent card name');
+    expect(cards).toHaveLength(0);
+  });
+
+  it('does not match non-contiguous substrings', async () => {
+    // "Add History" is not a contiguous substring of any card name
+    const cards = await client.getCardsByList('board1', 'list1', 'Add History');
+    expect(cards).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an optional `nameFilter` parameter to the `get_cards_by_list_id` tool
- When provided, filters cards client-side by case-insensitive substring match against the card name
- Without this, the only way to find a specific card by name is to fetch all cards and filter in the LLM context, which burns tokens unnecessarily
- Uses the same `toLowerCase().includes()` pattern as `findChecklistItemsByDescription`
- Fully backward compatible — omitting `nameFilter` returns all cards as before

## Changes

- `src/index.ts` — added `nameFilter` optional string to `inputSchema` and passed through to client
- `src/trello-client.ts` — added `nameFilter` parameter to `getCardsByList` with client-side filtering
- `tests/get-cards-name-filter.test.ts` — 8 unit tests covering exact match, substring, case-insensitivity, no match, and backward compatibility

## Test plan

- [x] `bun run build` compiles successfully
- [x] `bun test` — all 8 tests pass
- [ ] Manual test: call without `nameFilter` returns all cards (backward compatible)
- [ ] Manual test: call with `nameFilter` returns only matching cards