### PR TITLE
[codex] Add checklist item update and delete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,40 @@ Get a complete checklist with all items and completion percentage.
   - `items`: Array of `CheckListItem` objects
   - `percentComplete`: Completion percentage (0-100)
 
+#### update\_checklist\_item
+
+Update an existing checklist item.
+
+```typescript
+{
+  name: 'update_checklist_item',
+  arguments: {
+    cardId: string,                          // ID of the card containing the checklist item
+    checkItemId: string,                     // ID of the checklist item to update
+    name?: string,                           // Optional: new checklist item text
+    state?: 'complete' | 'incomplete',       // Optional: new checklist item state
+    pos?: number | 'top' | 'bottom',         // Optional: new checklist item position
+    due?: string | null,                     // Optional: ISO 8601 due date, or null to clear it
+    dueReminder?: number | null,             // Optional: reminder offset in minutes, or null to clear it
+    idMember?: string | null                 // Optional: member ID to assign, or null to clear it
+  }
+}
+```
+
+#### delete\_checklist\_item
+
+Delete an existing checklist item.
+
+```typescript
+{
+  name: 'delete_checklist_item',
+  arguments: {
+    cardId: string,       // ID of the card containing the checklist item
+    checkItemId: string   // ID of the checklist item to delete
+  }
+}
+```
+
 ### get\_card 🆕
 
 Get comprehensive details of a specific Trello card with human-level parity.

--- a/src/index.ts
+++ b/src/index.ts
@@ -981,20 +981,70 @@ class TrelloServer {
       'update_checklist_item',
       {
         title: 'Update Checklist Item',
-        description: 'Update a checklist item state (mark as complete or incomplete)',
+        description: 'Update a checklist item name, state, position, due date, reminder, or assigned member',
         inputSchema: {
           cardId: z.string().describe('ID of the card containing the checklist item'),
           checkItemId: z.string().describe('ID of the checklist item to update'),
           state: z
             .enum(['complete', 'incomplete'])
+            .optional()
             .describe('New state for the checklist item'),
+          name: z.string().optional().describe('New text for the checklist item'),
+          pos: z
+            .union([z.number(), z.enum(['top', 'bottom'])])
+            .optional()
+            .describe('New position for the checklist item'),
+          due: z
+            .string()
+            .nullable()
+            .optional()
+            .describe('New due date for the checklist item in ISO 8601 format, or null to clear it'),
+          dueReminder: z
+            .number()
+            .nullable()
+            .optional()
+            .describe('Reminder offset in minutes before due date, or null to clear it'),
+          idMember: z
+            .string()
+            .nullable()
+            .optional()
+            .describe('Member ID to assign to the checklist item, or null to clear it'),
         },
       },
-      async ({ cardId, checkItemId, state }) => {
+      async ({ cardId, checkItemId, name, state, pos, due, dueReminder, idMember }) => {
         try {
-          const item = await this.trelloClient.updateChecklistItem(cardId, checkItemId, state);
+          const item = await this.trelloClient.updateChecklistItem(cardId, checkItemId, {
+            name,
+            state,
+            pos,
+            due,
+            dueReminder,
+            idMember,
+          });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(item, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    this.server.registerTool(
+      'delete_checklist_item',
+      {
+        title: 'Delete Checklist Item',
+        description: 'Delete a checklist item from a card',
+        inputSchema: {
+          cardId: z.string().describe('ID of the card containing the checklist item'),
+          checkItemId: z.string().describe('ID of the checklist item to delete'),
+        },
+      },
+      async ({ cardId, checkItemId }) => {
+        try {
+          const deleted = await this.trelloClient.deleteChecklistItem(cardId, checkItemId);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ deleted }, null, 2) }],
           };
         } catch (error) {
           return this.handleError(error);

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -11,6 +11,7 @@ import {
   EnhancedTrelloCard,
   TrelloChecklist,
   TrelloCheckItem,
+  TrelloCheckItemUpdate,
   CheckList,
   CheckListItem,
   TrelloComment,
@@ -762,21 +763,40 @@ export class TrelloClient {
   }
 
   /**
-   * Update a checklist item state (complete/incomplete)
+   * Update a checklist item using Trello's supported mutable fields.
    */
   async updateChecklistItem(
     cardId: string,
     checkItemId: string,
-    state: 'complete' | 'incomplete'
+    updates: TrelloCheckItemUpdate
   ): Promise<TrelloCheckItem> {
+    const payload = Object.fromEntries(
+      Object.entries(updates).filter(([, value]) => value !== undefined)
+    ) as TrelloCheckItemUpdate;
+
+    if (Object.keys(payload).length === 0) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'At least one checklist item field must be provided'
+      );
+    }
+
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.put<TrelloCheckItem>(
         `/cards/${cardId}/checkItem/${checkItemId}`,
-        {
-          state,
-        }
+        payload
       );
       return response.data;
+    });
+  }
+
+  /**
+   * Delete a checklist item from a card.
+   */
+  async deleteChecklistItem(cardId: string, checkItemId: string): Promise<boolean> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.delete(`/cards/${cardId}/checkItem/${checkItemId}`);
+      return response.status >= 200 && response.status < 300;
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,15 @@ export interface TrelloCheckItem {
   idMember?: string | null;
 }
 
+export interface TrelloCheckItemUpdate {
+  name?: string;
+  state?: 'complete' | 'incomplete';
+  pos?: number | 'top' | 'bottom';
+  due?: string | null;
+  dueReminder?: number | null;
+  idMember?: string | null;
+}
+
 export interface TrelloChecklist {
   id: string;
   name: string;

--- a/test/trello-client.test.ts
+++ b/test/trello-client.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { TrelloClient } from '../src/trello-client.js';
+
+function createClient() {
+  return new TrelloClient({
+    apiKey: 'test-key',
+    token: 'test-token',
+  });
+}
+
+describe('TrelloClient checklist item mutations', () => {
+  test('updateChecklistItem sends supported Trello fields to the card checkItem endpoint', async () => {
+    const client = createClient();
+    const putCalls: Array<{ url: string; body: unknown }> = [];
+
+    (client as any).axiosInstance = {
+      put: async (url: string, body: unknown) => {
+        putCalls.push({ url, body });
+        return {
+          data: {
+            id: 'check-item-1',
+            name: 'Renamed item',
+            state: 'complete',
+            pos: 42,
+            due: '2026-04-20T10:00:00.000Z',
+            dueReminder: 60,
+            idMember: 'member-1',
+          },
+        };
+      },
+    };
+
+    const item = await client.updateChecklistItem('card-1', 'check-item-1', {
+      name: 'Renamed item',
+      state: 'complete',
+      pos: 42,
+      due: '2026-04-20T10:00:00.000Z',
+      dueReminder: 60,
+      idMember: 'member-1',
+    });
+
+    expect(putCalls).toEqual([
+      {
+        url: '/cards/card-1/checkItem/check-item-1',
+        body: {
+          name: 'Renamed item',
+          state: 'complete',
+          pos: 42,
+          due: '2026-04-20T10:00:00.000Z',
+          dueReminder: 60,
+          idMember: 'member-1',
+        },
+      },
+    ]);
+    expect(item.name).toBe('Renamed item');
+    expect(item.idMember).toBe('member-1');
+  });
+
+  test('updateChecklistItem rejects requests with no changes', async () => {
+    const client = createClient();
+
+    await expect(client.updateChecklistItem('card-1', 'check-item-1', {})).rejects.toMatchObject({
+      code: ErrorCode.InvalidParams,
+    } satisfies Partial<McpError>);
+  });
+
+  test('deleteChecklistItem deletes the item from the card endpoint', async () => {
+    const client = createClient();
+    const deleteCalls: string[] = [];
+
+    (client as any).axiosInstance = {
+      delete: async (url: string) => {
+        deleteCalls.push(url);
+        return { status: 200 };
+      },
+    };
+
+    const deleted = await client.deleteChecklistItem('card-1', 'check-item-1');
+
+    expect(deleteCalls).toEqual(['/cards/card-1/checkItem/check-item-1']);
+    expect(deleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed
- expanded `update_checklist_item` so it can send Trello's supported mutable check item fields instead of only toggling state
- added a new `delete_checklist_item` MCP tool for removing an existing checklist line from a card
- documented both checklist item mutation tools in the README and added focused Bun tests for update payloads, empty-update validation, and delete routing

## Why
Trello's API supports updating and deleting checklist items, including renaming an existing item. The gap was in this MCP server's tool surface, which only exposed state toggles.

## Impact
Clients can now rename checklist lines, move them, manage due metadata and assignment, and delete them without dropping down to raw Trello REST calls.

## Validation
- `bun test test/trello-client.test.ts`
- `bun run build`

## Notes
- this keeps the existing `cardId + checkItemId` call shape for compatibility with current MCP usage
- live behavior for Forge/OAuth2-restricted Trello app types was not verified in this change; the server continues to use the existing API key and token flow