### PR TITLE
Add generic attach_data_to_card tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -483,12 +483,65 @@ class TrelloServer {
       }
     );
 
-    // Attach image data to card (for base64/data URL uploads)
+    // Attach arbitrary binary data to a card (base64 or data URL)
+    this.server.registerTool(
+      'attach_data_to_card',
+      {
+        title: 'Attach Data to Card',
+        description:
+          'Attach binary data (image, markdown, PDF, text, etc.) to a card from base64-encoded data or a data URL. Use this for any non-image content. For image/screenshot uploads with PNG defaults, see attach_image_data_to_card.',
+        inputSchema: {
+          boardId: z
+            .string()
+            .optional()
+            .describe(
+              'ID of the Trello board where the card exists (uses default if not provided)'
+            ),
+          cardId: z.string().describe('ID of the card to attach the data to'),
+          data: z
+            .string()
+            .describe(
+              'Base64-encoded data or a data URL (e.g. data:text/markdown;base64,...). Any content type, not just images.'
+            ),
+          name: z
+            .string()
+            .optional()
+            .describe(
+              'Filename for the attachment, including extension (e.g. "notes.md", "report.pdf"). Defaults to "attachment-<timestamp>".'
+            ),
+          mimeType: z
+            .string()
+            .optional()
+            .describe(
+              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Required for correct rendering in Trello; defaults to "application/octet-stream" if omitted and not derivable from a data URL.'
+            ),
+        },
+      },
+      async ({ boardId, cardId, data, name, mimeType }) => {
+        try {
+          const attachment = await this.trelloClient.attachDataToCard(
+            boardId,
+            cardId,
+            data,
+            name,
+            mimeType
+          );
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(attachment, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    // Attach image data to card (image-flavored convenience over attach_data_to_card)
     this.server.registerTool(
       'attach_image_data_to_card',
       {
         title: 'Attach Image Data to Card',
-        description: 'Attach an image to a card from base64 data or data URL (for screenshot uploads)',
+        description:
+          'Attach an image to a card from base64 data or a data URL. Image-flavored convenience over attach_data_to_card: defaults assume PNG when mimeType/name are omitted, suitable for screenshot pasting. For non-image content, use attach_data_to_card.',
         inputSchema: {
           boardId: z
             .string()

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,7 @@ class TrelloServer {
             .string()
             .optional()
             .describe(
-              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Required for correct rendering in Trello; defaults to "application/octet-stream" if omitted and not derivable from a data URL.'
+              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Recommended for correct rendering in Trello. If omitted, inferred from a data URL prefix or the filename extension; falls back to "application/octet-stream".'
             ),
         },
       },

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -438,13 +438,13 @@ export class TrelloClient {
     return this.handleRequest(async () => {
       // Convert base64 or data URL to buffer
       let buffer: Buffer;
-      let effectiveMimeType = mimeType || 'application/octet-stream';
+      let effectiveMimeType = mimeType;
 
       if (data.startsWith('data:')) {
         // Extract mime type and base64 data from data URL
         const matches = data.match(/^data:([^;]+);base64,(.+)$/);
         if (matches) {
-          effectiveMimeType = matches[1];
+          effectiveMimeType = effectiveMimeType || matches[1];
           buffer = Buffer.from(matches[2], 'base64');
         } else {
           throw new McpError(ErrorCode.InvalidRequest, 'Invalid data URL format');
@@ -453,6 +453,13 @@ export class TrelloClient {
         // Assume it's raw base64
         buffer = Buffer.from(data, 'base64');
       }
+
+      // Fall back to filename extension lookup, then octet-stream
+      if (!effectiveMimeType && name) {
+        const ext = path.extname(name).toLowerCase();
+        effectiveMimeType = MIME_TYPES[ext];
+      }
+      effectiveMimeType = effectiveMimeType || 'application/octet-stream';
 
       // Create form data for multipart upload
       const form = new FormData();

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -428,21 +428,21 @@ export class TrelloClient {
     return this.attachFileToCard(boardId, cardId, imageUrl, name || 'Image Attachment', undefined);
   }
 
-  async attachImageDataToCard(
+  async attachDataToCard(
     boardId: string | undefined,
     cardId: string,
-    imageData: string,
+    data: string,
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
     return this.handleRequest(async () => {
       // Convert base64 or data URL to buffer
       let buffer: Buffer;
-      let effectiveMimeType = mimeType || 'image/png';
+      let effectiveMimeType = mimeType || 'application/octet-stream';
 
-      if (imageData.startsWith('data:')) {
+      if (data.startsWith('data:')) {
         // Extract mime type and base64 data from data URL
-        const matches = imageData.match(/^data:([^;]+);base64,(.+)$/);
+        const matches = data.match(/^data:([^;]+);base64,(.+)$/);
         if (matches) {
           effectiveMimeType = matches[1];
           buffer = Buffer.from(matches[2], 'base64');
@@ -451,12 +451,12 @@ export class TrelloClient {
         }
       } else {
         // Assume it's raw base64
-        buffer = Buffer.from(imageData, 'base64');
+        buffer = Buffer.from(data, 'base64');
       }
 
       // Create form data for multipart upload
       const form = new FormData();
-      const fileName = name || `screenshot-${Date.now()}.png`;
+      const fileName = name || `attachment-${Date.now()}`;
 
       form.append('file', buffer, {
         filename: fileName,
@@ -475,6 +475,20 @@ export class TrelloClient {
 
       return response.data;
     });
+  }
+
+  async attachImageDataToCard(
+    boardId: string | undefined,
+    cardId: string,
+    imageData: string,
+    name?: string,
+    mimeType?: string
+  ): Promise<TrelloAttachment> {
+    // Image-flavored convenience: defaults assume PNG when caller omits mimeType/name.
+    // For non-image content, prefer attachDataToCard.
+    const effectiveMimeType = mimeType || 'image/png';
+    const effectiveName = name || `screenshot-${Date.now()}.png`;
+    return this.attachDataToCard(boardId, cardId, imageData, effectiveName, effectiveMimeType);
   }
 
   async attachFileToCard(

--- a/tests/unit/trello-client.test.ts
+++ b/tests/unit/trello-client.test.ts
@@ -611,6 +611,130 @@ describe('TrelloClient', () => {
     });
   });
 
+  describe('attachDataToCard', () => {
+    const attachment = { id: 'a1', name: 'notes.md' };
+
+    it('should upload raw base64 with explicit mime type and name', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const result = await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('hello').toString('base64'),
+        'notes.md',
+        'text/markdown'
+      );
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/cards/c1/attachments',
+        expect.anything(),
+        expect.objectContaining({ headers: expect.any(Object) })
+      );
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+      expect(form.getBuffer().toString()).toContain('notes.md');
+      expect(result).toEqual(attachment);
+    });
+
+    it('should extract mime type and data from a data URL', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const dataUrl = `data:application/pdf;base64,${Buffer.from('pdf-bytes').toString('base64')}`;
+      await client.attachDataToCard(undefined, 'c1', dataUrl, 'report.pdf');
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/pdf');
+      expect(form.getBuffer().toString()).toContain('report.pdf');
+    });
+
+    it('should infer mime type from filename extension when not provided', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('# hi').toString('base64'),
+        'notes.md'
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+    });
+
+    it('should default to application/octet-stream when no mime hints exist', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('blob').toString('base64')
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/octet-stream');
+    });
+
+    it('should let an explicit mimeType override one parsed from a data URL', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const dataUrl = `data:application/octet-stream;base64,${Buffer.from('x').toString('base64')}`;
+      await client.attachDataToCard(undefined, 'c1', dataUrl, 'a.pdf', 'application/pdf');
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/pdf');
+      expect(form.getBuffer().toString()).not.toContain('application/octet-stream');
+    });
+
+    it('should reject a malformed data URL without uploading', async () => {
+      const client = createClient();
+      await expect(
+        client.attachDataToCard(undefined, 'c1', 'data:not-valid', 'x.bin')
+      ).rejects.toThrow();
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachImageDataToCard', () => {
+    const attachment = { id: 'a2', name: 'screenshot.png' };
+
+    it('should default to image/png and a screenshot filename when omitted', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachImageDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('png-bytes').toString('base64')
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('image/png');
+      expect(form.getBuffer().toString()).toMatch(/screenshot-\d+\.png/);
+    });
+
+    it('should respect a caller-supplied mime type and name', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachImageDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('jpg-bytes').toString('base64'),
+        'photo.jpg',
+        'image/jpeg'
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('image/jpeg');
+      expect(form.getBuffer().toString()).toContain('photo.jpg');
+    });
+  });
+
   describe('Config persistence', () => {
     it('activeBoardId should return configured board', () => {
       const client = createClient({ boardId: 'b1' });


### PR DESCRIPTION
## Summary

`attach_image_data_to_card` already accepts any binary data — under the hood it just buffers bytes and posts a multipart attachment to Trello. But every signal an MCP client sees says "images only": the tool name, title, description ("for screenshot uploads"), the `imageData` parameter, and the PNG/screenshot defaults. Reasonable clients conclude that markdown, PDFs, or other non-image content need to live somewhere else (external hosting, links in comments, etc.), even though the existing implementation handles them fine.

This PR adds a sibling tool, `attach_data_to_card`, whose surface matches its actual capability — and leaves `attach_image_data_to_card` untouched in behavior for callers that depend on its image-flavored defaults.

## What changes

**New tool: `attach_data_to_card`**
- Title: "Attach Data to Card"
- Description names common content types (image, markdown, PDF, text)
- Parameter `data` instead of `imageData`
- Defaults to `application/octet-stream` and `attachment-<timestamp>` — no assumed PNG
- Routes to a new client method `attachDataToCard`

**Existing tool: `attach_image_data_to_card`** — unchanged behavior
- Same name, same parameters, same defaults (PNG, `screenshot-<timestamp>.png`)
- Still useful for the screenshot-paste case
- Description now points to `attach_data_to_card` for non-image content
- Internally delegates to `attachDataToCard` after applying its image defaults

No breaking changes.

## Why two tools instead of generalizing the existing one

Renaming the tool or its parameter would break every client currently calling `attach_image_data_to_card`. Changing the defaults would silently change behavior for screenshot pasting — the dominant use case the existing tool was designed around. Two first-class tools, each named honestly for what it does, lets callers pick by intent without forcing a migration.

## Test plan

- [x] `bun build` succeeds
- [x] Existing test suite passes (1 unrelated failure in `updateChecklistItem` exists on `main` already)
- [ ] Manual: attach a markdown file via `attach_data_to_card` and confirm Trello renders it correctly
- [ ] Manual: confirm `attach_image_data_to_card` still works for screenshot pasting with no behavior change