### PR TITLE
refactor: extract attachments domain into focused module + tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -483,12 +483,65 @@ class TrelloServer {
       }
     );
 
-    // Attach image data to card (for base64/data URL uploads)
+    // Attach arbitrary binary data to a card (base64 or data URL)
+    this.server.registerTool(
+      'attach_data_to_card',
+      {
+        title: 'Attach Data to Card',
+        description:
+          'Attach binary data (image, markdown, PDF, text, etc.) to a card from base64-encoded data or a data URL. Use this for any non-image content. For image/screenshot uploads with PNG defaults, see attach_image_data_to_card.',
+        inputSchema: {
+          boardId: z
+            .string()
+            .optional()
+            .describe(
+              'ID of the Trello board where the card exists (uses default if not provided)'
+            ),
+          cardId: z.string().describe('ID of the card to attach the data to'),
+          data: z
+            .string()
+            .describe(
+              'Base64-encoded data or a data URL (e.g. data:text/markdown;base64,...). Any content type, not just images.'
+            ),
+          name: z
+            .string()
+            .optional()
+            .describe(
+              'Filename for the attachment, including extension (e.g. "notes.md", "report.pdf"). Defaults to "attachment-<timestamp>".'
+            ),
+          mimeType: z
+            .string()
+            .optional()
+            .describe(
+              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Required for correct rendering in Trello; defaults to "application/octet-stream" if omitted and not derivable from a data URL.'
+            ),
+        },
+      },
+      async ({ boardId, cardId, data, name, mimeType }) => {
+        try {
+          const attachment = await this.trelloClient.attachDataToCard(
+            boardId,
+            cardId,
+            data,
+            name,
+            mimeType
+          );
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(attachment, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    // Attach image data to card (image-flavored convenience over attach_data_to_card)
     this.server.registerTool(
       'attach_image_data_to_card',
       {
         title: 'Attach Image Data to Card',
-        description: 'Attach an image to a card from base64 data or data URL (for screenshot uploads)',
+        description:
+          'Attach an image to a card from base64 data or a data URL. Image-flavored convenience over attach_data_to_card: defaults assume PNG when mimeType/name are omitted, suitable for screenshot pasting. For non-image content, use attach_data_to_card.',
         inputSchema: {
           boardId: z
             .string()

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,7 @@ class TrelloServer {
             .string()
             .optional()
             .describe(
-              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Required for correct rendering in Trello; defaults to "application/octet-stream" if omitted and not derivable from a data URL.'
+              'MIME type of the data (e.g. "text/markdown", "application/pdf", "image/png"). Recommended for correct rendering in Trello. If omitted, inferred from a data URL prefix or the filename extension; falls back to "application/octet-stream".'
             ),
         },
       },

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -438,13 +438,13 @@ export class TrelloClient {
     return this.handleRequest(async () => {
       // Convert base64 or data URL to buffer
       let buffer: Buffer;
-      let effectiveMimeType = mimeType || 'application/octet-stream';
+      let effectiveMimeType = mimeType;
 
       if (data.startsWith('data:')) {
         // Extract mime type and base64 data from data URL
         const matches = data.match(/^data:([^;]+);base64,(.+)$/);
         if (matches) {
-          effectiveMimeType = matches[1];
+          effectiveMimeType = effectiveMimeType || matches[1];
           buffer = Buffer.from(matches[2], 'base64');
         } else {
           throw new McpError(ErrorCode.InvalidRequest, 'Invalid data URL format');
@@ -453,6 +453,13 @@ export class TrelloClient {
         // Assume it's raw base64
         buffer = Buffer.from(data, 'base64');
       }
+
+      // Fall back to filename extension lookup, then octet-stream
+      if (!effectiveMimeType && name) {
+        const ext = path.extname(name).toLowerCase();
+        effectiveMimeType = MIME_TYPES[ext];
+      }
+      effectiveMimeType = effectiveMimeType || 'application/octet-stream';
 
       // Create form data for multipart upload
       const form = new FormData();

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -428,21 +428,21 @@ export class TrelloClient {
     return this.attachFileToCard(boardId, cardId, imageUrl, name || 'Image Attachment', undefined);
   }
 
-  async attachImageDataToCard(
+  async attachDataToCard(
     boardId: string | undefined,
     cardId: string,
-    imageData: string,
+    data: string,
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
     return this.handleRequest(async () => {
       // Convert base64 or data URL to buffer
       let buffer: Buffer;
-      let effectiveMimeType = mimeType || 'image/png';
+      let effectiveMimeType = mimeType || 'application/octet-stream';
 
-      if (imageData.startsWith('data:')) {
+      if (data.startsWith('data:')) {
         // Extract mime type and base64 data from data URL
-        const matches = imageData.match(/^data:([^;]+);base64,(.+)$/);
+        const matches = data.match(/^data:([^;]+);base64,(.+)$/);
         if (matches) {
           effectiveMimeType = matches[1];
           buffer = Buffer.from(matches[2], 'base64');
@@ -451,12 +451,12 @@ export class TrelloClient {
         }
       } else {
         // Assume it's raw base64
-        buffer = Buffer.from(imageData, 'base64');
+        buffer = Buffer.from(data, 'base64');
       }
 
       // Create form data for multipart upload
       const form = new FormData();
-      const fileName = name || `screenshot-${Date.now()}.png`;
+      const fileName = name || `attachment-${Date.now()}`;
 
       form.append('file', buffer, {
         filename: fileName,
@@ -475,6 +475,20 @@ export class TrelloClient {
 
       return response.data;
     });
+  }
+
+  async attachImageDataToCard(
+    boardId: string | undefined,
+    cardId: string,
+    imageData: string,
+    name?: string,
+    mimeType?: string
+  ): Promise<TrelloAttachment> {
+    // Image-flavored convenience: defaults assume PNG when caller omits mimeType/name.
+    // For non-image content, prefer attachDataToCard.
+    const effectiveMimeType = mimeType || 'image/png';
+    const effectiveName = name || `screenshot-${Date.now()}.png`;
+    return this.attachDataToCard(boardId, cardId, imageData, effectiveName, effectiveMimeType);
   }
 
   async attachFileToCard(

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance, CreateAxiosDefaults } from 'axios';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import FormData from 'form-data';
 import {
   TrelloConfig,
   TrelloCard,
@@ -23,8 +22,7 @@ import { createTrelloRateLimiters } from './rate-limiter.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { createReadStream } from 'fs';
-import { fileURLToPath } from 'url';
+import * as attachments from './trello/attachments.js';
 
 // Path for storing active board/workspace configuration
 const CONFIG_DIR = path.join(process.env.HOME || process.env.USERPROFILE || '.', '.trello-mcp');
@@ -424,8 +422,9 @@ export class TrelloClient {
     imageUrl: string,
     name?: string
   ): Promise<TrelloAttachment> {
-    // Simply delegate to attachFileToCard - it will auto-detect MIME type for images
-    return this.attachFileToCard(boardId, cardId, imageUrl, name || 'Image Attachment', undefined);
+    return this.handleRequest(() =>
+      attachments.attachImage(this.axiosInstance, { cardId, imageUrl, name })
+    );
   }
 
   async attachDataToCard(
@@ -435,53 +434,9 @@ export class TrelloClient {
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
-    return this.handleRequest(async () => {
-      // Convert base64 or data URL to buffer
-      let buffer: Buffer;
-      let effectiveMimeType = mimeType;
-
-      if (data.startsWith('data:')) {
-        // Extract mime type and base64 data from data URL
-        const matches = data.match(/^data:([^;]+);base64,(.+)$/);
-        if (matches) {
-          effectiveMimeType = effectiveMimeType || matches[1];
-          buffer = Buffer.from(matches[2], 'base64');
-        } else {
-          throw new McpError(ErrorCode.InvalidRequest, 'Invalid data URL format');
-        }
-      } else {
-        // Assume it's raw base64
-        buffer = Buffer.from(data, 'base64');
-      }
-
-      // Fall back to filename extension lookup, then octet-stream
-      if (!effectiveMimeType && name) {
-        const ext = path.extname(name).toLowerCase();
-        effectiveMimeType = MIME_TYPES[ext];
-      }
-      effectiveMimeType = effectiveMimeType || 'application/octet-stream';
-
-      // Create form data for multipart upload
-      const form = new FormData();
-      const fileName = name || `attachment-${Date.now()}`;
-
-      form.append('file', buffer, {
-        filename: fileName,
-        contentType: effectiveMimeType,
-      });
-
-      form.append('name', fileName);
-      form.append('mimeType', effectiveMimeType);
-
-      // Upload file directly to Trello
-      const response = await this.axiosInstance.post(`/cards/${cardId}/attachments`, form, {
-        headers: {
-          ...form.getHeaders(),
-        },
-      });
-
-      return response.data;
-    });
+    return this.handleRequest(() =>
+      attachments.attachData(this.axiosInstance, { cardId, data, name, mimeType })
+    );
   }
 
   async attachImageDataToCard(
@@ -491,11 +446,9 @@ export class TrelloClient {
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
-    // Image-flavored convenience: defaults assume PNG when caller omits mimeType/name.
-    // For non-image content, prefer attachDataToCard.
-    const effectiveMimeType = mimeType || 'image/png';
-    const effectiveName = name || `screenshot-${Date.now()}.png`;
-    return this.attachDataToCard(boardId, cardId, imageData, effectiveName, effectiveMimeType);
+    return this.handleRequest(() =>
+      attachments.attachImageData(this.axiosInstance, { cardId, imageData, name, mimeType })
+    );
   }
 
   async attachFileToCard(
@@ -505,63 +458,9 @@ export class TrelloClient {
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
-    return this.handleRequest(async () => {
-      // Check if fileUrl is a local file path (starts with file://)
-      if (fileUrl.startsWith('file://')) {
-        // Handle local file upload
-        const localPath = fileURLToPath(fileUrl);
-        let effectiveMimeType = mimeType;
-        if (!effectiveMimeType) {
-          const ext = path.extname(localPath).toLowerCase();
-          effectiveMimeType = MIME_TYPES[ext] || 'application/octet-stream';
-        }
-
-        // Check if file exists
-        try {
-          await fs.access(localPath);
-        } catch (error) {
-          throw new McpError(ErrorCode.InvalidRequest, `File not found: ${localPath}`);
-        }
-
-        // Create form data for multipart upload
-        const form = new FormData();
-        const fileStream = createReadStream(localPath);
-        const fileName = name || path.basename(localPath);
-
-        form.append('file', fileStream, {
-          filename: fileName,
-          contentType: effectiveMimeType,
-        });
-
-        // Add name and mimeType to form
-        form.append('name', fileName);
-        form.append('mimeType', effectiveMimeType);
-
-        // Upload file directly to Trello using the configured axios instance
-        const response = await this.axiosInstance.post(`/cards/${cardId}/attachments`, form, {
-          headers: {
-            ...form.getHeaders(),
-          },
-        });
-
-        return response.data;
-      } else {
-        // Handle URL attachment
-        const remoteUrlPath = new URL(fileUrl).pathname;
-        let effectiveMimeType = mimeType;
-        if (!effectiveMimeType) {
-          const ext = path.extname(remoteUrlPath).toLowerCase();
-          effectiveMimeType = MIME_TYPES[ext] || 'application/octet-stream';
-        }
-
-        const response = await this.axiosInstance.post(`/cards/${cardId}/attachments`, {
-          url: fileUrl,
-          name: name || 'File Attachment',
-          mimeType: effectiveMimeType,
-        });
-        return response.data;
-      }
-    });
+    return this.handleRequest(() =>
+      attachments.attachFile(this.axiosInstance, { cardId, fileUrl, name, mimeType })
+    );
   }
 
   async getCard(
@@ -1280,61 +1179,3 @@ export class TrelloClient {
     });
   }
 }
-
-const MIME_TYPES: Readonly<{ [key: string]: string }> = Object.freeze({
-  // Images
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.gif': 'image/gif',
-  '.bmp': 'image/bmp',
-  '.svg': 'image/svg+xml',
-  '.webp': 'image/webp',
-  '.ico': 'image/x-icon',
-
-  // Documents
-  '.pdf': 'application/pdf',
-  '.doc': 'application/msword',
-  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  '.xls': 'application/vnd.ms-excel',
-  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  '.ppt': 'application/vnd.ms-powerpoint',
-  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-
-  // Text
-  '.txt': 'text/plain',
-  '.md': 'text/markdown',
-  '.csv': 'text/csv',
-  '.log': 'text/plain',
-
-  // Code
-  '.html': 'text/html',
-  '.htm': 'text/html',
-  '.css': 'text/css',
-  '.js': 'application/javascript',
-  '.mjs': 'application/javascript',
-  '.ts': 'application/typescript',
-  '.tsx': 'application/typescript',
-  '.jsx': 'application/javascript',
-  '.json': 'application/json',
-  '.xml': 'application/xml',
-  '.yaml': 'text/yaml',
-  '.yml': 'text/yaml',
-
-  // Archives
-  '.zip': 'application/zip',
-  '.tar': 'application/x-tar',
-  '.gz': 'application/gzip',
-  '.rar': 'application/vnd.rar',
-  '.7z': 'application/x-7z-compressed',
-
-  // Media
-  '.mp3': 'audio/mpeg',
-  '.wav': 'audio/wav',
-  '.mp4': 'video/mp4',
-  '.avi': 'video/x-msvideo',
-  '.mov': 'video/quicktime',
-  '.wmv': 'video/x-ms-wmv',
-  '.flv': 'video/x-flv',
-  '.webm': 'video/webm',
-});

--- a/src/trello/attachments.ts
+++ b/src/trello/attachments.ts
@@ -73,6 +73,11 @@ function mimeFromFilename(filename: string | undefined): string | undefined {
   return MIME_TYPES[ext];
 }
 
+function extensionFromMime(mimeType: string): string {
+  const match = Object.entries(MIME_TYPES).find(([, mime]) => mime === mimeType);
+  return match?.[0] ?? '';
+}
+
 export interface AttachDataParams {
   cardId: string;
   data: string;
@@ -100,7 +105,8 @@ export async function attachData(
 
   effectiveMimeType = effectiveMimeType || mimeFromFilename(name) || DEFAULT_MIME_TYPE;
 
-  const fileName = name || `attachment-${Date.now()}`;
+  const extension = extensionFromMime(effectiveMimeType);
+  const fileName = name || `attachment-${Date.now()}${extension}`;
   const form = new FormData();
   form.append('file', buffer, { filename: fileName, contentType: effectiveMimeType });
   form.append('name', fileName);
@@ -152,7 +158,12 @@ async function uploadLocalFile(
   axiosInstance: AxiosInstance,
   { cardId, fileUrl, name, mimeType }: AttachFileParams
 ): Promise<TrelloAttachment> {
-  const localPath = fileURLToPath(fileUrl);
+  let localPath: string;
+  try {
+    localPath = fileURLToPath(fileUrl);
+  } catch {
+    throw new McpError(ErrorCode.InvalidRequest, `Invalid file URL: ${fileUrl}`);
+  }
   const effectiveMimeType =
     mimeType || mimeFromFilename(localPath) || DEFAULT_MIME_TYPE;
 
@@ -181,7 +192,12 @@ async function attachRemoteUrl(
   axiosInstance: AxiosInstance,
   { cardId, fileUrl, name, mimeType }: AttachFileParams
 ): Promise<TrelloAttachment> {
-  const remoteUrlPath = new URL(fileUrl).pathname;
+  let remoteUrlPath: string;
+  try {
+    remoteUrlPath = new URL(fileUrl).pathname;
+  } catch {
+    throw new McpError(ErrorCode.InvalidRequest, `Invalid URL: ${fileUrl}`);
+  }
   const effectiveMimeType =
     mimeType || mimeFromFilename(remoteUrlPath) || DEFAULT_MIME_TYPE;
 

--- a/src/trello/attachments.ts
+++ b/src/trello/attachments.ts
@@ -1,0 +1,212 @@
+import { AxiosInstance } from 'axios';
+import FormData from 'form-data';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createReadStream } from 'fs';
+import { fileURLToPath } from 'url';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { TrelloAttachment } from '../types.js';
+
+export const MIME_TYPES: Readonly<{ [key: string]: string }> = Object.freeze({
+  // Images
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+
+  // Documents
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+
+  // Text
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.csv': 'text/csv',
+  '.log': 'text/plain',
+
+  // Code
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.ts': 'application/typescript',
+  '.tsx': 'application/typescript',
+  '.jsx': 'application/javascript',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+
+  // Archives
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+  '.rar': 'application/vnd.rar',
+  '.7z': 'application/x-7z-compressed',
+
+  // Media
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.mp4': 'video/mp4',
+  '.avi': 'video/x-msvideo',
+  '.mov': 'video/quicktime',
+  '.wmv': 'video/x-ms-wmv',
+  '.flv': 'video/x-flv',
+  '.webm': 'video/webm',
+});
+
+const DEFAULT_MIME_TYPE = 'application/octet-stream';
+
+function mimeFromFilename(filename: string | undefined): string | undefined {
+  if (!filename) return undefined;
+  const ext = path.extname(filename).toLowerCase();
+  return MIME_TYPES[ext];
+}
+
+export interface AttachDataParams {
+  cardId: string;
+  data: string;
+  name?: string;
+  mimeType?: string;
+}
+
+export async function attachData(
+  axiosInstance: AxiosInstance,
+  { cardId, data, name, mimeType }: AttachDataParams
+): Promise<TrelloAttachment> {
+  let buffer: Buffer;
+  let effectiveMimeType = mimeType;
+
+  if (data.startsWith('data:')) {
+    const matches = data.match(/^data:([^;]+);base64,(.+)$/);
+    if (!matches) {
+      throw new McpError(ErrorCode.InvalidRequest, 'Invalid data URL format');
+    }
+    effectiveMimeType = effectiveMimeType || matches[1];
+    buffer = Buffer.from(matches[2], 'base64');
+  } else {
+    buffer = Buffer.from(data, 'base64');
+  }
+
+  effectiveMimeType = effectiveMimeType || mimeFromFilename(name) || DEFAULT_MIME_TYPE;
+
+  const fileName = name || `attachment-${Date.now()}`;
+  const form = new FormData();
+  form.append('file', buffer, { filename: fileName, contentType: effectiveMimeType });
+  form.append('name', fileName);
+  form.append('mimeType', effectiveMimeType);
+
+  const response = await axiosInstance.post(`/cards/${cardId}/attachments`, form, {
+    headers: { ...form.getHeaders() },
+  });
+  return response.data;
+}
+
+export interface AttachImageDataParams {
+  cardId: string;
+  imageData: string;
+  name?: string;
+  mimeType?: string;
+}
+
+export async function attachImageData(
+  axiosInstance: AxiosInstance,
+  { cardId, imageData, name, mimeType }: AttachImageDataParams
+): Promise<TrelloAttachment> {
+  return attachData(axiosInstance, {
+    cardId,
+    data: imageData,
+    name: name || `screenshot-${Date.now()}.png`,
+    mimeType: mimeType || 'image/png',
+  });
+}
+
+export interface AttachFileParams {
+  cardId: string;
+  fileUrl: string;
+  name?: string;
+  mimeType?: string;
+}
+
+export async function attachFile(
+  axiosInstance: AxiosInstance,
+  { cardId, fileUrl, name, mimeType }: AttachFileParams
+): Promise<TrelloAttachment> {
+  if (fileUrl.startsWith('file://')) {
+    return uploadLocalFile(axiosInstance, { cardId, fileUrl, name, mimeType });
+  }
+  return attachRemoteUrl(axiosInstance, { cardId, fileUrl, name, mimeType });
+}
+
+async function uploadLocalFile(
+  axiosInstance: AxiosInstance,
+  { cardId, fileUrl, name, mimeType }: AttachFileParams
+): Promise<TrelloAttachment> {
+  const localPath = fileURLToPath(fileUrl);
+  const effectiveMimeType =
+    mimeType || mimeFromFilename(localPath) || DEFAULT_MIME_TYPE;
+
+  try {
+    await fs.access(localPath);
+  } catch {
+    throw new McpError(ErrorCode.InvalidRequest, `File not found: ${localPath}`);
+  }
+
+  const fileName = name || path.basename(localPath);
+  const form = new FormData();
+  form.append('file', createReadStream(localPath), {
+    filename: fileName,
+    contentType: effectiveMimeType,
+  });
+  form.append('name', fileName);
+  form.append('mimeType', effectiveMimeType);
+
+  const response = await axiosInstance.post(`/cards/${cardId}/attachments`, form, {
+    headers: { ...form.getHeaders() },
+  });
+  return response.data;
+}
+
+async function attachRemoteUrl(
+  axiosInstance: AxiosInstance,
+  { cardId, fileUrl, name, mimeType }: AttachFileParams
+): Promise<TrelloAttachment> {
+  const remoteUrlPath = new URL(fileUrl).pathname;
+  const effectiveMimeType =
+    mimeType || mimeFromFilename(remoteUrlPath) || DEFAULT_MIME_TYPE;
+
+  const response = await axiosInstance.post(`/cards/${cardId}/attachments`, {
+    url: fileUrl,
+    name: name || 'File Attachment',
+    mimeType: effectiveMimeType,
+  });
+  return response.data;
+}
+
+export interface AttachImageParams {
+  cardId: string;
+  imageUrl: string;
+  name?: string;
+}
+
+export async function attachImage(
+  axiosInstance: AxiosInstance,
+  { cardId, imageUrl, name }: AttachImageParams
+): Promise<TrelloAttachment> {
+  // attachFile auto-detects MIME type for images via the URL extension
+  return attachFile(axiosInstance, {
+    cardId,
+    fileUrl: imageUrl,
+    name: name || 'Image Attachment',
+  });
+}

--- a/tests/unit/trello-client.test.ts
+++ b/tests/unit/trello-client.test.ts
@@ -611,6 +611,130 @@ describe('TrelloClient', () => {
     });
   });
 
+  describe('attachDataToCard', () => {
+    const attachment = { id: 'a1', name: 'notes.md' };
+
+    it('should upload raw base64 with explicit mime type and name', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const result = await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('hello').toString('base64'),
+        'notes.md',
+        'text/markdown'
+      );
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/cards/c1/attachments',
+        expect.anything(),
+        expect.objectContaining({ headers: expect.any(Object) })
+      );
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+      expect(form.getBuffer().toString()).toContain('notes.md');
+      expect(result).toEqual(attachment);
+    });
+
+    it('should extract mime type and data from a data URL', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const dataUrl = `data:application/pdf;base64,${Buffer.from('pdf-bytes').toString('base64')}`;
+      await client.attachDataToCard(undefined, 'c1', dataUrl, 'report.pdf');
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/pdf');
+      expect(form.getBuffer().toString()).toContain('report.pdf');
+    });
+
+    it('should infer mime type from filename extension when not provided', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('# hi').toString('base64'),
+        'notes.md'
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+    });
+
+    it('should default to application/octet-stream when no mime hints exist', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('blob').toString('base64')
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/octet-stream');
+    });
+
+    it('should let an explicit mimeType override one parsed from a data URL', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      const dataUrl = `data:application/octet-stream;base64,${Buffer.from('x').toString('base64')}`;
+      await client.attachDataToCard(undefined, 'c1', dataUrl, 'a.pdf', 'application/pdf');
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/pdf');
+      expect(form.getBuffer().toString()).not.toContain('application/octet-stream');
+    });
+
+    it('should reject a malformed data URL without uploading', async () => {
+      const client = createClient();
+      await expect(
+        client.attachDataToCard(undefined, 'c1', 'data:not-valid', 'x.bin')
+      ).rejects.toThrow();
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachImageDataToCard', () => {
+    const attachment = { id: 'a2', name: 'screenshot.png' };
+
+    it('should default to image/png and a screenshot filename when omitted', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachImageDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('png-bytes').toString('base64')
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('image/png');
+      expect(form.getBuffer().toString()).toMatch(/screenshot-\d+\.png/);
+    });
+
+    it('should respect a caller-supplied mime type and name', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: attachment });
+      const client = createClient();
+
+      await client.attachImageDataToCard(
+        undefined,
+        'c1',
+        Buffer.from('jpg-bytes').toString('base64'),
+        'photo.jpg',
+        'image/jpeg'
+      );
+
+      const form = mockAxiosInstance.post.mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('image/jpeg');
+      expect(form.getBuffer().toString()).toContain('photo.jpg');
+    });
+  });
+
   describe('Config persistence', () => {
     it('activeBoardId should return configured board', () => {
       const client = createClient({ boardId: 'b1' });

--- a/tests/unit/trello/attachments.test.ts
+++ b/tests/unit/trello/attachments.test.ts
@@ -124,6 +124,28 @@ describe('attachments', () => {
       expect(form.getBuffer().toString()).toMatch(/attachment-\d+/);
     });
 
+    it('appends an inferred extension to the generated filename when mime type is known', async () => {
+      const axiosInstance = createAxiosMock();
+      const dataUrl = `data:application/pdf;base64,${Buffer.from('pdf').toString('base64')}`;
+
+      await attachData(axiosInstance, { cardId: 'c1', data: dataUrl });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toMatch(/attachment-\d+\.pdf/);
+    });
+
+    it('omits the extension when mime type has no entry in MIME_TYPES', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: Buffer.from('blob').toString('base64'),
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toMatch(/attachment-\d+(?!\.)/);
+    });
+
     it('rejects a malformed data URL without uploading', async () => {
       const axiosInstance = createAxiosMock();
 
@@ -232,6 +254,15 @@ describe('attachments', () => {
       await expect(
         attachFile(axiosInstance, { cardId: 'c1', fileUrl: `file://${missing}` })
       ).rejects.toThrow(/File not found/);
+      expect(axiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('throws InvalidRequest on a malformed remote URL', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await expect(
+        attachFile(axiosInstance, { cardId: 'c1', fileUrl: 'not-a-url' })
+      ).rejects.toThrow(/Invalid URL/);
       expect(axiosInstance.post).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/trello/attachments.test.ts
+++ b/tests/unit/trello/attachments.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AxiosInstance } from 'axios';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  attachData,
+  attachImage,
+  attachImageData,
+  attachFile,
+  MIME_TYPES,
+} from '../../../src/trello/attachments.js';
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('fs/promises')>('fs/promises');
+  return { ...actual };
+});
+
+function createAxiosMock(): AxiosInstance {
+  const post = vi.fn().mockResolvedValue({ data: { id: 'a1' } });
+  const get = vi.fn();
+  return { post, get } as unknown as AxiosInstance;
+}
+
+describe('attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('MIME_TYPES', () => {
+    it('should be frozen', () => {
+      expect(Object.isFrozen(MIME_TYPES)).toBe(true);
+    });
+
+    it('should map common extensions', () => {
+      expect(MIME_TYPES['.md']).toBe('text/markdown');
+      expect(MIME_TYPES['.pdf']).toBe('application/pdf');
+      expect(MIME_TYPES['.png']).toBe('image/png');
+    });
+  });
+
+  describe('attachData', () => {
+    it('uploads raw base64 with explicit name and mime type', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: Buffer.from('hello').toString('base64'),
+        name: 'notes.md',
+        mimeType: 'text/markdown',
+      });
+
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        '/cards/c1/attachments',
+        expect.anything(),
+        expect.objectContaining({ headers: expect.any(Object) })
+      );
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+      expect(form.getBuffer().toString()).toContain('notes.md');
+    });
+
+    it('extracts mime type and bytes from a data URL', async () => {
+      const axiosInstance = createAxiosMock();
+      const dataUrl = `data:application/pdf;base64,${Buffer.from('pdf').toString('base64')}`;
+
+      await attachData(axiosInstance, { cardId: 'c1', data: dataUrl, name: 'r.pdf' });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/pdf');
+    });
+
+    it('infers mime type from filename extension when omitted', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: Buffer.from('# hi').toString('base64'),
+        name: 'notes.md',
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('text/markdown');
+    });
+
+    it('falls back to application/octet-stream when no hints exist', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: Buffer.from('blob').toString('base64'),
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toContain('application/octet-stream');
+    });
+
+    it('lets explicit mimeType override one parsed from a data URL', async () => {
+      const axiosInstance = createAxiosMock();
+      const dataUrl = `data:application/octet-stream;base64,${Buffer.from('x').toString('base64')}`;
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: dataUrl,
+        name: 'a.pdf',
+        mimeType: 'application/pdf',
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const body = form.getBuffer().toString();
+      expect(body).toContain('application/pdf');
+      expect(body).not.toContain('application/octet-stream');
+    });
+
+    it('uses a generated filename when name is omitted', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachData(axiosInstance, {
+        cardId: 'c1',
+        data: Buffer.from('blob').toString('base64'),
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(form.getBuffer().toString()).toMatch(/attachment-\d+/);
+    });
+
+    it('rejects a malformed data URL without uploading', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await expect(
+        attachData(axiosInstance, { cardId: 'c1', data: 'data:not-valid', name: 'x.bin' })
+      ).rejects.toThrow(/Invalid data URL/);
+      expect(axiosInstance.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachImageData', () => {
+    it('defaults to image/png and a screenshot filename', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachImageData(axiosInstance, {
+        cardId: 'c1',
+        imageData: Buffer.from('png').toString('base64'),
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const body = form.getBuffer().toString();
+      expect(body).toContain('image/png');
+      expect(body).toMatch(/screenshot-\d+\.png/);
+    });
+
+    it('respects caller-supplied mime type and name', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachImageData(axiosInstance, {
+        cardId: 'c1',
+        imageData: Buffer.from('jpg').toString('base64'),
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const body = form.getBuffer().toString();
+      expect(body).toContain('image/jpeg');
+      expect(body).toContain('photo.jpg');
+    });
+  });
+
+  describe('attachFile', () => {
+    it('attaches a remote URL with explicit mime type', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachFile(axiosInstance, {
+        cardId: 'c1',
+        fileUrl: 'https://example.com/doc.pdf',
+        name: 'doc.pdf',
+        mimeType: 'application/pdf',
+      });
+
+      expect(axiosInstance.post).toHaveBeenCalledWith('/cards/c1/attachments', {
+        url: 'https://example.com/doc.pdf',
+        name: 'doc.pdf',
+        mimeType: 'application/pdf',
+      });
+    });
+
+    it('infers mime type from a remote URL extension', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachFile(axiosInstance, {
+        cardId: 'c1',
+        fileUrl: 'https://example.com/notes.md',
+      });
+
+      expect(axiosInstance.post).toHaveBeenCalledWith('/cards/c1/attachments', {
+        url: 'https://example.com/notes.md',
+        name: 'File Attachment',
+        mimeType: 'text/markdown',
+      });
+    });
+
+    it('uploads a local file:// URL as multipart form data', async () => {
+      const tmpFile = path.join(os.tmpdir(), `attachments-test-${Date.now()}.md`);
+      await fs.writeFile(tmpFile, '# hello');
+      try {
+        const axiosInstance = createAxiosMock();
+
+        await attachFile(axiosInstance, {
+          cardId: 'c1',
+          fileUrl: `file://${tmpFile}`,
+        });
+
+        expect(axiosInstance.post).toHaveBeenCalledWith(
+          '/cards/c1/attachments',
+          expect.anything(),
+          expect.objectContaining({ headers: expect.any(Object) })
+        );
+        // Form contains a stream so getBuffer() is unavailable; assert on form fields directly.
+        const form = (axiosInstance.post as ReturnType<typeof vi.fn>).mock.calls[0][1];
+        const fields = (form as unknown as { _streams: unknown[] })._streams.join('\n');
+        expect(fields).toContain('text/markdown');
+        expect(fields).toContain(path.basename(tmpFile));
+      } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+      }
+    });
+
+    it('throws on a missing local file', async () => {
+      const axiosInstance = createAxiosMock();
+      const missing = path.join(os.tmpdir(), `does-not-exist-${Date.now()}.txt`);
+
+      await expect(
+        attachFile(axiosInstance, { cardId: 'c1', fileUrl: `file://${missing}` })
+      ).rejects.toThrow(/File not found/);
+      expect(axiosInstance.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attachImage', () => {
+    it('delegates to attachFile with a default name', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachImage(axiosInstance, {
+        cardId: 'c1',
+        imageUrl: 'https://example.com/cat.png',
+      });
+
+      expect(axiosInstance.post).toHaveBeenCalledWith('/cards/c1/attachments', {
+        url: 'https://example.com/cat.png',
+        name: 'Image Attachment',
+        mimeType: 'image/png',
+      });
+    });
+
+    it('respects a caller-supplied name', async () => {
+      const axiosInstance = createAxiosMock();
+
+      await attachImage(axiosInstance, {
+        cardId: 'c1',
+        imageUrl: 'https://example.com/cat.png',
+        name: 'cat',
+      });
+
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        '/cards/c1/attachments',
+        expect.objectContaining({ name: 'cat' })
+      );
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #81, addressing the Gemini review feedback about file size and test coverage on the attach* family. Stacked on top of `generic-attach-data-tool` — once #81 merges, this PR's diff will narrow to the refactor commit only.

## Summary
- Extracts the attachment domain out of `TrelloClient` into `src/trello/attachments.ts` as pure functions taking an `AxiosInstance` and a params object.
- Moves the `MIME_TYPES` table to live next to the code that uses it.
- `TrelloClient` methods (`attachDataToCard`, `attachImageDataToCard`, `attachFileToCard`, `attachImageToCard`) become thin wrappers that delegate via `handleRequest`. **Public API unchanged.**
- Adds `tests/unit/trello/attachments.test.ts` — 17 tests covering the extracted module (explicit/derived/inferred mime types, data URL parsing, octet-stream fallback, generated filenames, malformed data URL rejection, local `file://` uploads with mime inference and missing-file errors, image convenience defaults, and `attachImage` delegation).

## Why this shape
A pure-function module keeps the `TrelloClient` shared state (`axiosInstance`, `rateLimiter`, `handleRequest`, config persistence) in one place while letting each domain be tested in isolation without setting up the whole client. The class becomes a thin facade.

## File size
This is a first step, not the whole answer. `src/trello-client.ts` drops from 1340 → 1181 lines; still over the 500-line target. The same pattern can be applied in follow-up PRs to extract cards, lists, checklists, members, labels, and the markdown formatter — happy to do those as separate, reviewable PRs rather than one mega-diff.

## Test plan
- [x] `bun run build` clean
- [x] `bunx vitest run tests/unit/trello/attachments.test.ts` — 17/17 pass
- [x] `bunx vitest run tests/unit/trello-client.test.ts` — pre-existing tests still pass through the new delegation (one unrelated `updateChecklistItem` failure exists on `main` and is not introduced here)
- [ ] Manual smoke against a real Trello board after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)