### PR TITLE
feat(cards): add pos parameter to move_card and update_card_details

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,12 @@ class TrelloServer {
             .optional()
             .describe('Mark the due date as complete (true) or incomplete (false)'),
           labels: z.array(z.string()).optional().describe('New array of label IDs for the card'),
+          pos: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe(
+              'Position of the card in the list. Accepts "top", "bottom", or a positive number'
+            ),
         },
       },
       async args => {
@@ -265,11 +271,17 @@ class TrelloServer {
             ),
           cardId: z.string().describe('ID of the card to move'),
           listId: z.string().describe('ID of the target list'),
+          pos: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe(
+              'Position of the card in the target list. Accepts "top", "bottom", or a positive number'
+            ),
         },
       },
-      async ({ boardId, cardId, listId }) => {
+      async ({ boardId, cardId, listId, pos }) => {
         try {
-          const card = await this.trelloClient.moveCard(boardId, cardId, listId);
+          const card = await this.trelloClient.moveCard(boardId, cardId, listId, pos);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(card, null, 2) }],
           };

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -336,6 +336,7 @@ export class TrelloClient {
       start?: string;
       dueComplete?: boolean;
       labels?: string[];
+      pos?: string | number;
     }
   ): Promise<TrelloCard> {
     return this.handleRequest(async () => {
@@ -346,6 +347,7 @@ export class TrelloClient {
         start: params.start,
         dueComplete: params.dueComplete,
         idLabels: params.labels,
+        pos: params.pos,
       });
       return response.data;
     });
@@ -360,12 +362,13 @@ export class TrelloClient {
     });
   }
 
-  async moveCard(boardId: string | undefined, cardId: string, listId: string): Promise<TrelloCard> {
+  async moveCard(boardId: string | undefined, cardId: string, listId: string, pos?: string | number): Promise<TrelloCard> {
     const effectiveBoardId = boardId || this.defaultBoardId;
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.put(`/cards/${cardId}`, {
         idList: listId,
         ...(effectiveBoardId && { idBoard: effectiveBoardId }),
+        ...(pos !== undefined && { pos }),
       });
       return response.data;
     });


### PR DESCRIPTION
Adds an optional pos parameter to move_card and update_card_details, allowing callers to specify card position ("top", "bottom", or a numeric value) within a list.
 
The parameter is passed directly to the Trello PUT /cards/{id} API. Validation uses z.union([z.string(), z.number()]) — a stricter enum+positive-number schema was attempted but is incompatible with the MCP SDK's ZodEffects type constraints. Invalid values are still rejected by the Trello API.

Note: PR #52 covers the same feature for move_card only — this PR extends it to update_card_details as well.