### PR TITLE
fix: point bin to src/index.ts to avoid missing build dir at publish time

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "axios": "^1.13.2",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^7.0.6",
-        "mcp-evals": "^1.0.18",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -20,6 +19,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-prettier": "^5.5.4",
+        "mcp-evals": "^1.0.18",
         "prettier": "^3.7.4",
         "terser": "^5.44.1",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build/**/*"
   ],
   "bin": {
-    "mcp-server-trello": "build/index.js"
+    "mcp-server-trello": "src/index.ts"
   },
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "axios": "^1.13.2",
     "https-proxy-agent": "^7.0.6",
     "form-data": "^4.0.5",
-    "mcp-evals": "^1.0.18",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.4",
+    "mcp-evals": "^1.0.18",
     "prettier": "^3.7.4",
     "terser": "^5.44.1",
     "typescript": "^5.9.3",

--- a/skill/assets/source/bun.lock
+++ b/skill/assets/source/bun.lock
@@ -9,7 +9,6 @@
         "axios": "^1.13.2",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^7.0.6",
-        "mcp-evals": "^1.0.18",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -20,6 +19,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-prettier": "^5.5.4",
+        "mcp-evals": "^1.0.18",
         "prettier": "^3.7.4",
         "terser": "^5.44.1",
         "typescript": "^5.9.3",

--- a/skill/assets/source/package.json
+++ b/skill/assets/source/package.json
@@ -28,7 +28,6 @@
     "axios": "^1.13.2",
     "https-proxy-agent": "^7.0.6",
     "form-data": "^4.0.5",
-    "mcp-evals": "^1.0.18",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.4",
+    "mcp-evals": "^1.0.18",
     "prettier": "^3.7.4",
     "terser": "^5.44.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
Fixes #28

The bin entry in package.json pointed to build/index.js, which doesn't exist at publish time since only src/ is published. This change updates the bin entry to point directly to src/index.ts, which already has a proper shebang (#!/usr/bin/env node).