### PR TITLE
Move mcp-evals to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "axios": "^1.13.2",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^7.0.6",
-        "mcp-evals": "^1.0.18",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -20,6 +19,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-prettier": "^5.5.4",
+        "mcp-evals": "^1.0.18",
         "prettier": "^3.7.4",
         "terser": "^5.44.1",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "axios": "^1.13.2",
     "https-proxy-agent": "^7.0.6",
     "form-data": "^4.0.5",
-    "mcp-evals": "^1.0.18",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.4",
+    "mcp-evals": "^1.0.18",
     "prettier": "^3.7.4",
     "terser": "^5.44.1",
     "typescript": "^5.9.3",

--- a/skill/assets/source/bun.lock
+++ b/skill/assets/source/bun.lock
@@ -9,7 +9,6 @@
         "axios": "^1.13.2",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^7.0.6",
-        "mcp-evals": "^1.0.18",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -20,6 +19,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-prettier": "^5.5.4",
+        "mcp-evals": "^1.0.18",
         "prettier": "^3.7.4",
         "terser": "^5.44.1",
         "typescript": "^5.9.3",

--- a/skill/assets/source/package.json
+++ b/skill/assets/source/package.json
@@ -28,7 +28,6 @@
     "axios": "^1.13.2",
     "https-proxy-agent": "^7.0.6",
     "form-data": "^4.0.5",
-    "mcp-evals": "^1.0.18",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.4",
+    "mcp-evals": "^1.0.18",
     "prettier": "^3.7.4",
     "terser": "^5.44.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
Fixes #77

mcp-evals was in `dependencies` but is only used for testing/eval — not imported in the bundled `build/index.js`. Moved to `devDependencies` in:
- package.json (root)
- skill/assets/source/package.json (bundled skill source)
- bun.lock and skill/assets/source/bun.lock refreshed

This eliminates 6 npm audit vulnerabilities (1 high, 3 moderate, 2 low) from production installs.