### PR TITLE
fix(security): add SSRF protection and retry limit

### DIFF
--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -26,6 +26,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as attachments from './trello/attachments.js';
+import { validateExternalUrl } from './url-validator.js';
 
 // Path for storing active board/workspace configuration
 const CONFIG_DIR = path.join(process.env.HOME || process.env.USERPROFILE || '.', '.trello-mcp');
@@ -202,27 +203,32 @@ export class TrelloClient {
     return workspace;
   }
 
+  private static readonly MAX_RETRY_ATTEMPTS = 3;
+
   private async handleRequest<T extends TrelloRequestReturn>(
-    requestFn: () => Promise<T>
+    requestFn: () => Promise<T>,
+    retryCount: number = 0
   ): Promise<T> {
     try {
       return await requestFn();
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        if (error.response?.status === 429) {
-          // Rate limit exceeded, wait and retry
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          return this.handleRequest(requestFn);
+        if (error.response?.status === 429 && retryCount < TrelloClient.MAX_RETRY_ATTEMPTS) {
+          await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+          return this.handleRequest(requestFn, retryCount + 1);
         }
-        // Trello API Error
-        // Customize error handling based on Trello's error structure if needed
+        if (error.response?.status === 429) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            `Trello API rate limit exceeded after ${TrelloClient.MAX_RETRY_ATTEMPTS} retries`
+          );
+        }
         throw new McpError(
           ErrorCode.InternalError,
           `Trello API Error: ${error.response?.status} ${error.message}`,
           error.response?.data
         );
       } else {
-        // Unexpected Error
         throw new McpError(ErrorCode.InternalError, 'An unexpected error occurred');
       }
     }
@@ -522,6 +528,7 @@ export class TrelloClient {
     imageUrl: string,
     name?: string
   ): Promise<TrelloAttachment> {
+    validateExternalUrl(imageUrl);
     return this.handleRequest(() =>
       attachments.attachImage(this.axiosInstance, { cardId, imageUrl, name })
     );
@@ -558,6 +565,9 @@ export class TrelloClient {
     name?: string,
     mimeType?: string
   ): Promise<TrelloAttachment> {
+    if (!fileUrl.startsWith('file://')) {
+      validateExternalUrl(fileUrl);
+    }
     return this.handleRequest(() =>
       attachments.attachFile(this.axiosInstance, { cardId, fileUrl, name, mimeType })
     );

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -214,7 +214,7 @@ export class TrelloClient {
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 429 && retryCount < TrelloClient.MAX_RETRY_ATTEMPTS) {
-          await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+          await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount)));
           return this.handleRequest(requestFn, retryCount + 1);
         }
         if (error.response?.status === 429) {
@@ -528,7 +528,9 @@ export class TrelloClient {
     imageUrl: string,
     name?: string
   ): Promise<TrelloAttachment> {
-    validateExternalUrl(imageUrl);
+    if (!imageUrl.startsWith('file://')) {
+      validateExternalUrl(imageUrl);
+    }
     return this.handleRequest(() =>
       attachments.attachImage(this.axiosInstance, { cardId, imageUrl, name })
     );

--- a/src/url-validator.ts
+++ b/src/url-validator.ts
@@ -1,0 +1,42 @@
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\.\d+\.\d+\.\d+$/,
+  /^10\.\d+\.\d+\.\d+$/,
+  /^172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+$/,
+  /^192\.168\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/,
+  /^0\.\d+\.\d+\.\d+$/,
+  /^\[::1\]$/,
+  /^fc[0-9a-f]{2}:/i,
+  /^fe80:/i,
+  /^::$/,
+];
+
+export function validateExternalUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new McpError(ErrorCode.InvalidRequest, `Invalid URL: ${url}`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `Only HTTPS URLs are allowed, got: ${parsed.protocol}`
+    );
+  }
+
+  const hostname = parsed.hostname;
+
+  for (const pattern of PRIVATE_HOST_PATTERNS) {
+    if (pattern.test(hostname)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `URLs pointing to private or local addresses are not allowed: ${hostname}`
+      );
+    }
+  }
+}

--- a/src/url-validator.ts
+++ b/src/url-validator.ts
@@ -1,18 +1,62 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import * as net from 'net';
 
-const PRIVATE_HOST_PATTERNS = [
-  /^localhost$/i,
-  /^127\.\d+\.\d+\.\d+$/,
-  /^10\.\d+\.\d+\.\d+$/,
-  /^172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+$/,
-  /^192\.168\.\d+\.\d+$/,
-  /^169\.254\.\d+\.\d+$/,
-  /^0\.\d+\.\d+\.\d+$/,
-  /^\[::1\]$/,
-  /^fc[0-9a-f]{2}:/i,
-  /^fe80:/i,
-  /^::$/,
-];
+function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const parts = ip.split('.').map(Number);
+    const first = parts[0];
+    const second = parts[1];
+
+    // 127.0.0.0/8 (Loopback)
+    if (first === 127) return true;
+    // 10.0.0.0/8 (Private)
+    if (first === 10) return true;
+    // 172.16.0.0/12 (Private)
+    if (first === 172 && second >= 16 && second <= 31) return true;
+    // 192.168.0.0/16 (Private)
+    if (first === 192 && second === 168) return true;
+    // 169.254.0.0/16 (Link-local)
+    if (first === 169 && second === 254) return true;
+    // 0.0.0.0/8 (Broadcast/unspecified)
+    if (first === 0) return true;
+
+    return false;
+  }
+
+  if (net.isIPv6(ip)) {
+    const normalized = ip.toLowerCase();
+
+    // Loopback ::1
+    if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') return true;
+    // Unspecified ::
+    if (normalized === '::' || normalized === '0:0:0:0:0:0:0:0') return true;
+
+    // Unique Local Address (fc00::/7)
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+
+    // Link-local (fe80::/10)
+    if (
+      normalized.startsWith('fe8') ||
+      normalized.startsWith('fe9') ||
+      normalized.startsWith('fea') ||
+      normalized.startsWith('feb')
+    ) {
+      return true;
+    }
+
+    // IPv4-mapped IPv6 (::ffff:127.0.0.1)
+    if (normalized.startsWith('::ffff:')) {
+      const ipv4Part = normalized.substring(7);
+      if (net.isIPv4(ipv4Part)) {
+        return isPrivateIp(ipv4Part);
+      }
+    }
+
+    return false;
+  }
+
+  return false;
+}
 
 export function validateExternalUrl(url: string): void {
   let parsed: URL;
@@ -31,12 +75,24 @@ export function validateExternalUrl(url: string): void {
 
   const hostname = parsed.hostname;
 
-  for (const pattern of PRIVATE_HOST_PATTERNS) {
-    if (pattern.test(hostname)) {
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `URLs pointing to private or local addresses are not allowed: ${hostname}`
-      );
-    }
+  // Handle localhost explicitly
+  if (hostname.toLowerCase() === 'localhost') {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `URLs pointing to private or local addresses are not allowed: ${hostname}`
+    );
+  }
+
+  // Strip brackets for IPv6 check
+  let ipToCheck = hostname;
+  if (ipToCheck.startsWith('[') && ipToCheck.endsWith(']')) {
+    ipToCheck = ipToCheck.slice(1, -1);
+  }
+
+  if (isPrivateIp(ipToCheck)) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `URLs pointing to private or local addresses are not allowed: ${hostname}`
+    );
   }
 }


### PR DESCRIPTION
## Summary

This PR addresses two security concerns identified during a security audit of the codebase:

### 1. SSRF Protection via URL Validation

**Problem:** The `attachImageToCard` and `attachFileToCard` methods accepted arbitrary URLs without validation, making the server vulnerable to Server-Side Request Forgery (SSRF) attacks. An attacker could craft requests to internal network resources (localhost, private IPs, link-local addresses).

**Fix:** Added `url-validator.ts` with `validateExternalUrl()` that:
- Enforces HTTPS-only URLs
- Blocks requests to private/local network addresses (RFC 1918, loopback, link-local)
- Blocks IPv6 private addresses (fc00::/7, fe80::/10, ::1)

Applied in `trello-client.ts` to both `attachImageToCard` and `attachFileToCard` (skipped for `file://` URLs which are local file uploads).

### 2. Retry Limit on Rate Limiting (429)

**Problem:** The `handleRequest` method retried indefinitely on HTTP 429 (rate limit) responses with exponential backoff but no maximum retry count. This could cause the process to hang or consume resources indefinitely.

**Fix:** Added `MAX_RETRY_ATTEMPTS = 3` constant and retry count tracking with exponential backoff capped at 3 retries.

## Files Changed

- `src/url-validator.ts` (new) — URL validation for SSRF prevention
- `src/trello-client.ts` (modified) — retry limit + URL validation integration

## Testing

- Docker image builds successfully with `docker build -t mcp-server-trello .`
- TypeScript compiles without errors
- npm audit reports 0 vulnerabilities