### PR TITLE
Fix stale contributing links and README formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ We love your input! We want to make contributing to MCP Trello Server as easy an
 - Proposing new features
 - Becoming a maintainer
 
-## We Develop with Github
+## We Develop with GitHub
 We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html)
+## We Use [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow)
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `main`.
@@ -24,8 +24,8 @@ Pull requests are the best way to propose changes to the codebase. We actively w
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issue tracker](https://github.com/modelcontextprotocol/server-trello/issues)
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/modelcontextprotocol/server-trello/issues/new); it's that easy!
+## Report bugs using GitHub's [issue tracker](https://github.com/delorenj/mcp-server-trello/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/delorenj/mcp-server-trello/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server that provides tools for interacting with T
 ### ✨ New in This Release:
 
   - 🚀 **Performance Boost**: Enjoy a faster, more responsive server.
-  -  BUN **Bun-Powered**: The project now runs on the lightning-fast Bun runtime.
+  - **Bun-Powered**: The project now runs on the lightning-fast Bun runtime.
   - 📖 **Comprehensive Examples**: A new `examples` directory with detailed implementations in JavaScript, Python, and TypeScript.
 
 **Plus:** Modern MCP SDK architecture, enhanced type safety, and comprehensive documentation!
@@ -106,7 +106,7 @@ You can get these values from:
 
   - API Key: [https://trello.com/app-key](https://trello.com/app-key)
   - Token: Generate using your API key
-  - Board ID (optional, deprecated): Found in the board URL (e.g., [suspicious link removed])
+  - Board ID (optional, deprecated): Found in the board URL (e.g., `https://trello.com/b/abc123/example-board`)
   - Workspace ID: Found in workspace settings or using `list_workspaces` tool
 
 ### Board and Workspace Management


### PR DESCRIPTION
Small docs cleanup:

- fixes the contributing guide's issue tracker links so they point to this repository instead of `modelcontextprotocol/server-trello`
- normalizes `GitHub` capitalization in the contributing guide
- cleans up a small README release-note formatting glitch
- replaces an unusable board URL placeholder with a concrete Trello URL example

No code behavior changed.