### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Jarad DeLorenzo",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/delorenj/mcp-server-trello.git"
+  },
   "bugs": {
     "url": "https://github.com/delorenj/mcp-server-trello/issues"
   },


### PR DESCRIPTION
## Summary
- Add npm `repository` metadata pointing to this public GitHub repository.

## Why
The published package currently exposes `homepage` and `bugs`, but no `repository` field through npm:

```shell
npm view @delorenj/mcp-server-trello name version repository bugs homepage --json
```

Observed for 1.7.1:

```json
{
  "name": "@delorenj/mcp-server-trello",
  "version": "1.7.1",
  "bugs": {
    "url": "https://github.com/delorenj/mcp-server-trello/issues"
  },
  "homepage": "https://github.com/delorenj/mcp-server-trello#readme"
}
```

Adding `repository` makes it easier for npm users and automated tooling to locate the source package repository.

## Validation
- package metadata parsed successfully with Node.js
- `git diff --check -- package.json`
