### PR TITLE
Add repository metadata to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   ],
   "author": "Jarad DeLorenzo",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/delorenj/mcp-server-trello.git"
+  },
   "bugs": {
     "url": "https://github.com/delorenj/mcp-server-trello/issues"
   },


### PR DESCRIPTION
## Summary
- Add the missing npm `repository` metadata to the root package manifest.
- Keep the existing `homepage`, `bugs`, runtime code, dependencies, and version unchanged.

## Validation
- `node -e "const p=require('./package.json'); if (p.name !== '@delorenj/mcp-server-trello') throw new Error('wrong package'); if (p.repository?.type !== 'git') throw new Error('missing repository type'); if (p.repository?.url !== 'git+https://github.com/delorenj/mcp-server-trello.git') throw new Error('missing repository url'); if (p.bugs?.url !== 'https://github.com/delorenj/mcp-server-trello/issues') throw new Error('bugs changed'); if (p.homepage !== 'https://github.com/delorenj/mcp-server-trello#readme') throw new Error('homepage changed'); console.log(JSON.stringify({name:p.name, repository:p.repository, bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

## Bounty claim
- Source micro-bounty: https://github.com/charles-openclaw/charles-microbounties/issues/340
- This PR addresses the acceptance path by adding the missing `repository` metadata for `@delorenj/mcp-server-trello`.
- Payment/account setup, if selected, remains owner-only.

AI assistance disclosure: AI assistance was used to identify the bounty, prepare the small metadata patch, and run validation. I reviewed the final diff before submission.