### PR TITLE
feat: add watch_card and watch_list tools for activity subscription

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,52 @@ class TrelloServer {
       }
     );
 
+    // ─── Watch Card (subscribe/unsubscribe) ──
+    this.server.registerTool(
+      'watch_card',
+      {
+        title: 'Watch Card',
+        description: 'Subscribe or unsubscribe from watching a card for activity notifications',
+        inputSchema: {
+          cardId: z.string().describe('ID of the card to watch/unwatch'),
+          subscribed: z.boolean().describe('Set to true to start watching, false to stop'),
+        },
+      },
+      async ({ cardId, subscribed }) => {
+        try {
+          const card = await this.trelloClient.watchCard(cardId, subscribed);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(card, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    // ─── Watch List (subscribe/unsubscribe) ──
+    this.server.registerTool(
+      'watch_list',
+      {
+        title: 'Watch List',
+        description: 'Subscribe or unsubscribe from watching a list for activity notifications',
+        inputSchema: {
+          listId: z.string().describe('ID of the list to watch/unwatch'),
+          subscribed: z.boolean().describe('Set to true to start watching, false to stop'),
+        },
+      },
+      async ({ listId, subscribed }) => {
+        try {
+          const list = await this.trelloClient.watchList(listId, subscribed);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(list, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
     // Move a card
     this.server.registerTool(
       'move_card',

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -529,12 +529,7 @@ export class TrelloClient {
   }
 
   async watchList(listId: string, subscribed: boolean): Promise<TrelloList> {
-    return this.handleRequest(async () => {
-      const response = await this.axiosInstance.put(`/lists/${listId}`, {
-        subscribed,
-      });
-      return response.data;
-    });
+    return this.updateList(listId, { subscribed });
   }
 
   async getMyCards(): Promise<TrelloCard[]> {

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -519,6 +519,24 @@ export class TrelloClient {
     });
   }
 
+  async watchCard(cardId: string, subscribed: boolean): Promise<TrelloCard> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.put(`/cards/${cardId}`, {
+        subscribed,
+      });
+      return response.data;
+    });
+  }
+
+  async watchList(listId: string, subscribed: boolean): Promise<TrelloList> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.put(`/lists/${listId}`, {
+        subscribed,
+      });
+      return response.data;
+    });
+  }
+
   async getMyCards(): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/members/me/cards');


### PR DESCRIPTION
﻿## Description

Add two new MCP tools for subscribing to card and list activity notifications.

### `watch_card`
Subscribe or unsubscribe from watching a card. When watching, the user receives notifications for activity on that card.

### `watch_list`
Subscribe or unsubscribe from watching a list. When watching, the user receives notifications for activity on that list.

## Changes
- `src/trello-client.ts` — Add `watchCard` and `watchList` methods
- `src/index.ts` — Register both tools with Zod input schemas

## API
- `PUT /cards/{cardId}` with `subscribed: true/false`
- `PUT /lists/{listId}` with `subscribed: true/false`

## Testing
Both tools tested against Trello API and confirmed working.
