### PR TITLE
feat: add search_labels and remove_label_from_card tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1430,6 +1430,60 @@ class TrelloServer {
       }
     );
 
+    // ─── Search Labels ──
+    this.server.registerTool(
+      'search_labels',
+      {
+        title: 'Search Labels',
+        description: 'Search labels on a board by name or color',
+        inputSchema: {
+          boardId: z
+            .string()
+            .optional()
+            .describe('ID of the Trello board (uses default if not provided)'),
+          query: z.string().describe('Search query to filter labels by name or color'),
+        },
+      },
+      async ({ boardId, query }) => {
+        try {
+          const labels = await this.trelloClient.searchLabels(boardId, query);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ labels }, null, 2) }],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
+    // ─── Remove Label from Card ──
+    this.server.registerTool(
+      'remove_label_from_card',
+      {
+        title: 'Remove Label from Card',
+        description: 'Remove a label from a specific card',
+        inputSchema: {
+          cardId: z.string().describe('ID of the card'),
+          labelId: z.string().describe('ID of the label to remove'),
+        },
+      },
+      async ({ cardId, labelId }) => {
+        try {
+          const success = await this.trelloClient.removeLabelFromCard(cardId, labelId);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: success ? 'Label removed successfully' : 'Failed to remove label',
+              },
+            ],
+          };
+        } catch (error) {
+          return this.handleError(error);
+        }
+      }
+    );
+
     // Copy a card (supports cross-board copy)
     this.server.registerTool(
       'copy_card',

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1166,7 +1166,9 @@ export class TrelloClient {
       const labels: TrelloLabelDetails[] = response.data;
       const q = query.toLowerCase();
       return labels.filter(
-        (l) => l.name.toLowerCase().includes(q) || l.color.toLowerCase().includes(q)
+        (l) =>
+          (l.name || '').toLowerCase().includes(q) ||
+          (l.color || '').toLowerCase().includes(q)
       );
     });
   }

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1153,6 +1153,31 @@ export class TrelloClient {
     });
   }
 
+  async searchLabels(boardId: string | undefined, query: string): Promise<TrelloLabelDetails[]> {
+    const effectiveBoardId = boardId || this.activeConfig.boardId || this.defaultBoardId;
+    if (!effectiveBoardId) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'boardId is required when no default board is configured'
+      );
+    }
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.get(`/boards/${effectiveBoardId}/labels`);
+      const labels: TrelloLabelDetails[] = response.data;
+      const q = query.toLowerCase();
+      return labels.filter(
+        (l) => l.name.toLowerCase().includes(q) || l.color.toLowerCase().includes(q)
+      );
+    });
+  }
+
+  async removeLabelFromCard(cardId: string, labelId: string): Promise<boolean> {
+    return this.handleRequest(async () => {
+      await this.axiosInstance.delete(`/cards/${cardId}/idLabels/${labelId}`);
+      return true;
+    });
+  }
+
   /**
    * Copy a card (can copy across boards). Uses idCardSource to clone a card.
    */


### PR DESCRIPTION
﻿## Description

Add two new MCP tools for label management:

### `search_labels`
Search labels on a board by name or color. Returns all matching labels with id, name, and color.

### `remove_label_from_card`
Remove a specific label from a card.

## Changes
- `src/trello-client.ts` — Add `searchLabels` and `removeLabelFromCard` methods
- `src/index.ts` — Register both tools with Zod input schemas

## API
- `GET /boards/{boardId}/labels` — with client-side filtering by name/color
- `DELETE /cards/{cardId}/idLabels/{labelId}` — remove label from card

## Testing
Both tools tested against Trello API and confirmed working.
