### PR TITLE
ci: fix publish-script recursion + skip-if-already-published guards

### DIFF
--- a/.agents/skills/mcp-server-trello-release/SKILL.md
+++ b/.agents/skills/mcp-server-trello-release/SKILL.md
@@ -254,3 +254,15 @@ chase the registry error in isolation.
 - `gh release create` under the current workflows. → duplicate/red registry publish.
 - Direct-pushing a bump to `main`. → registry publishes, npm doesn't; the two desync.
 - Cutting a release with red/absent `ci.yml` coverage. → merge blocked or main goes red.
+- **Naming a `package.json` script after an npm lifecycle event** (`publish`,
+  `prepare`, `pack`, `version`, …). The repo shipped `"publish": "bun run build
+  && npm publish"`; because `publish` is a lifecycle hook, CI's `npm publish`
+  re-invoked it → a **recursive second publish** that `E403`'d ("cannot publish
+  over previously published X.Y.Z") and **false-red'd every successful release**.
+  It was masked for months only because auth failed on the *first* publish. Fixed
+  2026-07-20 by renaming it to **`release`**. Local publish is now `npm run release`.
+- **Reading a green `publish-npm` run as proof a publish happened.** The publish
+  steps now self-skip an already-published version (guard → clean `exit 0`, still
+  green). Green means "npm/registry is at the package's declared version," not
+  "we uploaded just now." Always confirm the actual bytes with
+  `npm view @delorenj/mcp-server-trello version`.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -45,4 +45,12 @@ jobs:
       - name: Publish to NPM (Trusted Publishing / OIDC)
         # No NODE_AUTH_TOKEN: auth is via the OIDC id-token above.
         # Provenance is generated and attested automatically under Trusted Publishing.
-        run: npm publish
+        # Guard: skip cleanly if this version is already on npm, so non-release
+        # merges (which also fire this workflow) don't fail on a duplicate publish.
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@delorenj/mcp-server-trello@${VERSION}" version >/dev/null 2>&1; then
+            echo "@delorenj/mcp-server-trello@${VERSION} is already published — skipping."
+            exit 0
+          fi
+          npm publish

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -40,4 +40,14 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # Guard: skip cleanly if server.json's version is already registered, so a
+        # push touching package.json/server.json without a version bump doesn't
+        # fail on a duplicate registration.
+        run: |
+          VERSION=$(node -p "require('./server.json').version")
+          if curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.delorenj/mcp-server-trello" \
+             | tr -d ' \n' | grep -q "\"version\":\"${VERSION}\""; then
+            echo "io.github.delorenj/mcp-server-trello@${VERSION} is already registered — skipping."
+            exit 0
+          fi
+          ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "test:smoke": "vitest run tests/smoke",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "publish": "bun run build && npm publish"
+    "release": "bun run build && npm publish"
   }
 }


### PR DESCRIPTION
## Context

Trusted Publishing landed 1.8.0 on npm (with provenance) and the MCP registry — both are live at `1.8.0`. But the `publish-npm` run still went **red**, and this PR fixes why, plus removes the class of false-reds it exposed.

## The footgun

`package.json` defined:

```json
"publish": "bun run build && npm publish"
```

`publish` is an **npm lifecycle hook**. So CI's `npm publish` ran the real publish (success + provenance) and then re-invoked the `publish` script → a **recursive second publish** → `E403 "cannot publish over previously published 1.8.0"` → exit 1. It was invisible for months only because auth failed on the *first* publish; the instant publishing actually worked, it surfaced.

## Changes

- **Rename `publish` → `release`** in `package.json`. Local publish is now `npm run release`. (Nothing referenced the old name.)
- **`publish-npm.yml`**: skip cleanly (`exit 0`) if `package.json`'s version is already on npm — so non-release PR merges, which also fire this workflow, stop false-reding on a duplicate publish.
- **`publish-registry.yml`**: same guard against the MCP registry for `server.json`'s version.
- **Release skill**: documents both gotchas — the lifecycle-name footgun, and that a green `publish-npm` no longer proves an upload happened (a guard-skip is also green; confirm with `npm view`).

## Expected on merge

Both publish workflows fire, both see `1.8.0` already present, both **skip → green**. That green *is* the test that the guards work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
