### PR TITLE
fix: unref health monitor interval so the server can exit (#92)

### DIFF
--- a/src/health/health-monitor.ts
+++ b/src/health/health-monitor.ts
@@ -70,6 +70,7 @@ export class TrelloHealthMonitor {
   private lastHealthCheck?: SystemHealthReport;
   private readonly trelloClient: TrelloClient;
   private rateLimiter: any; // Will get injected from TrelloClient
+  private performanceTimer?: ReturnType<typeof setInterval>;
 
   constructor(trelloClient: TrelloClient) {
     this.trelloClient = trelloClient;
@@ -615,13 +616,35 @@ export class TrelloHealthMonitor {
    */
   private startPerformanceMonitoring(): void {
     // Simple monitoring - in a real implementation, this might be more sophisticated
-    setInterval(() => {
+    this.performanceTimer = setInterval(() => {
       // Clean up old metrics to prevent memory leaks
       const fiveMinutesAgo = Date.now() - 300000;
       this.performanceTracker.requests = this.performanceTracker.requests.filter(
         r => r.timestamp > fiveMinutesAgo
       );
     }, 60000); // Clean up every minute
+
+    // Never let this timer hold the event loop open. The server runs over stdio,
+    // so when the client disconnects its stdin EOFs and there is no work left to
+    // do -- but a referenced timer keeps Node alive indefinitely, leaving the
+    // process reparented to init and running forever. This is purely opportunistic
+    // cleanup of an in-memory array, so it should not by itself keep the process
+    // alive. See #92.
+    this.performanceTimer.unref?.();
+  }
+
+  /**
+   * Stop background performance monitoring and release its timer.
+   *
+   * Not required for the process to exit (the timer is unref'd), but lets an
+   * embedding host tear the monitor down deterministically, and keeps tests from
+   * leaking timers between cases.
+   */
+  stopPerformanceMonitoring(): void {
+    if (this.performanceTimer) {
+      clearInterval(this.performanceTimer);
+      this.performanceTimer = undefined;
+    }
   }
 
   /**

--- a/tests/unit/health-monitor-timer.test.ts
+++ b/tests/unit/health-monitor-timer.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { TrelloHealthMonitor } from '../../src/health/health-monitor.js';
+
+/**
+ * The health monitor starts a background interval that prunes old performance
+ * samples. Because the server runs over stdio, that timer must not keep the Node
+ * event loop alive: when the client disconnects, stdin EOFs and there is no work
+ * left, but a referenced timer keeps the process running forever and it ends up
+ * reparented to init. See #92.
+ */
+describe('TrelloHealthMonitor background timer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('unrefs its interval so it cannot hold the event loop open', () => {
+    const unref = vi.fn();
+    const spy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockReturnValue({ unref, ref: vi.fn() } as unknown as ReturnType<typeof setInterval>);
+
+    new TrelloHealthMonitor({} as never);
+
+    expect(spy).toHaveBeenCalled();
+    expect(unref).toHaveBeenCalled();
+  });
+
+  it('clears the interval when monitoring is stopped', () => {
+    const handle = { unref: vi.fn(), ref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    vi.spyOn(globalThis, 'setInterval').mockReturnValue(handle);
+    const clear = vi.spyOn(globalThis, 'clearInterval').mockImplementation(() => undefined);
+
+    const monitor = new TrelloHealthMonitor({} as never);
+    monitor.stopPerformanceMonitoring();
+
+    expect(clear).toHaveBeenCalledWith(handle);
+
+    // Stopping twice must not clear a stale handle a second time.
+    clear.mockClear();
+    monitor.stopPerformanceMonitoring();
+    expect(clear).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #92.

`TrelloHealthMonitor.startPerformanceMonitoring()` creates a 60s interval whose handle is never stored, cleared, or `unref`'d. In Node a referenced timer keeps the event loop alive indefinitely, so a server started over stdio never exits once its client goes away: stdin EOFs and there is no work left to do, but the timer pins the process, which is reparented to init and runs forever.

The interval only prunes an in-memory array of recent request timestamps, so it has no reason to keep the process alive on its own.

### Change

- store the interval handle and `unref()` it
- add `stopPerformanceMonitoring()` to clear it deterministically, which also stops tests leaking timers between cases

### Reproduction

Against the **published 1.8.1 build**, send an `initialize` request over stdio and then close stdin:

| build | result |
|---|---|
| 1.8.1 as published | still running 21s after stdin closed |
| with this change | exits within ~1s of stdin closing |

### Impact

This surfaced on a host that had accumulated **294 orphaned `mcp-server-trello` processes over 59 days of uptime, holding 6.5 GB of swap** — every one idle, parentless, and unreachable. 256 came from scheduled jobs that load the server via a shared MCP config and never call a Trello tool at all.

Worth noting that sibling stdio MCP servers launched exactly the same way (via `npx`) exit cleanly on the same host, which is what narrowed it to this timer rather than anything in the transport or launcher.

### Tests

- new `tests/unit/health-monitor-timer.test.ts` asserts the interval is `unref`'d and that `stopPerformanceMonitoring()` clears it (and is idempotent)
- verified the new test fails if the `unref()` line is removed
- `tsc --noEmit` clean; full suite passes (143 tests)

### Note

`unref?.()` is an optional call because `ReturnType<typeof setInterval>` is `NodeJS.Timeout` under Node types but `number` under DOM lib. Happy to make it a bare `unref()` if you'd rather assume Node types.

Credit to @andb for the diagnosis in #92 — the root cause was already correctly identified there; this just adds the patch.
