### PR TITLE
ci: prerelease-aware release tooling (beta via @next, registry stays stable-only)

### DIFF
--- a/.agents/skills/mcp-server-trello-release/scripts/parity-check.sh
+++ b/.agents/skills/mcp-server-trello-release/scripts/parity-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # parity-check.sh — assert the 5 version-bearing locations in mcp-server-trello
-# all read the same X.Y.Z. Exit 0 if in parity, 1 otherwise.
+# all read the same X.Y.Z[-prerelease]. Exit 0 if in parity, 1 otherwise.
 # Safe to run anywhere inside the repo, and safe as a CI gate.
 set -euo pipefail
 
@@ -11,9 +11,9 @@ pkg=$(node -p "require('$ROOT/package.json').version")
 srv_top=$(node -p "require('$ROOT/server.json').version")
 srv_pkg=$(node -p "require('$ROOT/server.json').packages[0].version")
 # McpServer info literal — anchored on the server name so it can't match elsewhere.
-mcp=$(grep -A1 "name: 'trello-server'" src/index.ts | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+mcp=$(grep -A1 "name: 'trello-server'" src/index.ts | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | head -1)
 # Newest changelog heading.
-chlog=$(grep -m1 -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+chlog=$(grep -m1 -oE '## \[[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?')
 
 printf '%-28s %s\n' "package.json version"          "$pkg"
 printf '%-28s %s\n' "server.json version"           "$srv_top"

--- a/.agents/skills/mcp-server-trello-release/scripts/set-version.sh
+++ b/.agents/skills/mcp-server-trello-release/scripts/set-version.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# set-version.sh <X.Y.Z> — set ALL four version literals in mcp-server-trello at
+# set-version.sh <X.Y.Z[-prerelease]> — set ALL four version literals in mcp-server-trello at
 # once (package.json, server.json ×2, src/index.ts McpServer info) and flip the
 # CHANGELOG "[Unreleased]" heading to the versioned one. Does NOT commit.
 # This exists because `bun run versionbump` only touches package.json.
 set -euo pipefail
 
 NEW="${1:-}"
-if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "usage: set-version.sh <X.Y.Z>   (e.g. set-version.sh 1.8.0)" >&2
+if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "usage: set-version.sh <X.Y.Z[-prerelease]>   (e.g. set-version.sh 1.8.0 or 2.0.0-beta.0)" >&2
   exit 1
 fi
 
@@ -22,7 +22,7 @@ node -e "const f='$ROOT/package.json',j=require(f);j.version='$NEW';require('fs'
 node -e "const f='$ROOT/server.json',j=require(f);j.version='$NEW';if(j.packages&&j.packages[0])j.packages[0].version='$NEW';require('fs').writeFileSync(f,JSON.stringify(j,null,2)+'\n')"
 
 # 4. src/index.ts McpServer info literal (anchored on the trello-server name).
-perl -0pi -e "s/(name: 'trello-server',\s*\n\s*version: ')[0-9]+\.[0-9]+\.[0-9]+(')/\${1}$NEW\${2}/" src/index.ts
+perl -0pi -e "s/(name: 'trello-server',\s*\n\s*version: ')[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(')/\${1}$NEW\${2}/" src/index.ts
 
 # 5. CHANGELOG heading: [Unreleased] -> [X.Y.Z] - DATE (first occurrence only).
 if grep -q '## \[Unreleased\]' CHANGELOG.md; then

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       package_version: ${{ steps.version.outputs.package_version }}
       release_ready: ${{ steps.verify-npm.outputs.release_ready }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
 
     steps:
       - name: Checkout repository
@@ -69,6 +70,11 @@ jobs:
           echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
           echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
           echo "dist_tag=$(node scripts/npm-dist-tag.js "$package_version")" >> "$GITHUB_OUTPUT"
+          if node -e "process.exit(/^\d+\.\d+\.\d+-[0-9A-Za-z-]/.test('$package_version') ? 0 : 1)"; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
           published_versions=$(node scripts/npm-published-versions.js "$package_name")
           if PUBLISHED_VERSIONS="$published_versions" PACKAGE_VERSION="$package_version" node -e \
@@ -148,7 +154,9 @@ jobs:
           exit 1
 
   publish-registry:
-    if: github.event_name == 'release' && needs.publish-npm.outputs.release_ready == 'true'
+    # Prereleases (beta/rc) publish to npm under the `next` dist-tag only;
+    # the official MCP Registry lists stable releases only.
+    if: github.event_name == 'release' && needs.publish-npm.outputs.release_ready == 'true' && needs.publish-npm.outputs.is_prerelease == 'false'
     needs: publish-npm
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

- `set-version.sh` and `parity-check.sh` now accept full semver including prereleases (`2.0.0-beta.0`). The perl substitution and parity extraction are prerelease-aware, so bumping FROM a beta TO a stable (or beta-to-beta) can't corrupt the literals.
- `publish-npm.yml` computes `is_prerelease` in the version step (same rule as `npm-dist-tag.js`) and the `publish-registry` job now skips prereleases.

## Why

Beta releases (e.g. `2.0.0-beta.0`) already publish to npm under the `next` dist-tag thanks to `npm-dist-tag.js` — `@latest` never moves. But the official MCP Registry listed every published version, including betas. After this PR, the registry only ever sees stable releases.

## Verified

- `set-version.sh 2.0.0-beta.0` run end-to-end on a scratch repo: all five literals set, parity-check green.
- Regex accept/reject table tested (accepts 1.8.1 / 2.0.0-beta / 2.0.0-rc.1; rejects 1.8 / x.y.z / 2.0.0-).
- Workflow YAML parses.